### PR TITLE
Add Slack message on domain check error

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  Test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -56,11 +56,16 @@ jobs:
         if not success:
             raise Exception(f"Domain check failed for ${{ matrix.domain }} with prefix '${{ matrix.prefix }}'")
 
-    - name: Notify on failure
-      if: github.event_name == 'schedule' && failure() # do not notify on cancelled() as cancelling is performed by hand
-      uses: slackapi/slack-github-action@v1.25.0
-      with:
-        payload: |
-          {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}
+  Summary:
+    runs-on: ubuntu-latest
+    needs: [Test] # Add job names that you want to check for failure
+    if: always() # This ensures the job runs even if previous jobs fail
+    steps:
+      - name: Check for failure and notify
+        if: needs.Test.result == 'failure' && github.repository == 'ultralytics/docs' && (github.event_name == 'schedule' || github.event_name == 'push')
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}

--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -55,3 +55,12 @@ jobs:
         success = check_domain_redirection('${{ matrix.domain }}', '${{ matrix.prefix }}')
         if not success:
             raise Exception(f"Domain check failed for ${{ matrix.domain }} with prefix '${{ matrix.prefix }}'")
+
+    - name: Notify on failure
+      if: github.event_name == 'schedule' && failure() # do not notify on cancelled() as cancelling is performed by hand
+      uses: slackapi/slack-github-action@v1.25.0
+      with:
+        payload: |
+          {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}


### PR DESCRIPTION
@kalenmike adds Slack message to Website channel if this daily test fails

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to GitHub Actions workflow with Slack notifications on failure.

### 📊 Key Changes
- Added a new step in the workflow to send notifications to Slack.
- Notifications are triggered only if the workflow fails during a scheduled run, not if it is manually cancelled.

### 🎯 Purpose & Impact
- **Facilitates Immediate Alerts:** The team will receive instant notifications on Slack if the scheduled domain check fails, promoting a quicker response to resolve issues.
- **Reduces Noise:** By excluding notifications for cancelled runs, the team avoids unnecessary alerts, keeping the focus on genuine problems.