### PR TITLE
Fix installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ To install the ultralytics package in developer mode, ensure you have Git and Py
    cd ultralytics
    ```
 
-3. Install the package in developer mode using pip (or pip3 for Python 3):
+3. Install the package in editable mode for development using pip (or pip3 for Python 3):
 
    ```bash
-   pip install -e '.[dev]'
+   pip install -e .
    ```
 
 - This command installs the ultralytics package along with all development dependencies, allowing you to modify the package code and have the changes immediately reflected in your Python environment.


### PR DESCRIPTION
Hi,
fix install guide command for `pyproject.toml`. I tried to install using this guide:
-` pip install -e '.[dev]'` does not work, seems like it should be `pip install -e .` instead! (as described in the .toml file or Quickstart in Docs)

Thanks!