### PR TITLE
Update links.yml to 900s delay

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ultralytics/actions/retry@main
         with:
           timeout_minutes: 60
-          retry_delay_seconds: 300
+          retry_delay_seconds: 900
           retries: 2
           run: |
             # Count successfully downloaded files


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Increased the retry delay for a GitHub Actions workflow to improve stability. 🚀

### 📊 Key Changes
- Modified the `retry_delay_seconds` from 300 seconds (5 minutes) to 900 seconds (15 minutes) in the GitHub Actions workflow configuration.

### 🎯 Purpose & Impact
- **Purpose:** This change is intended to provide more time between retry attempts, potentially reducing the strain on resources and preventing failures due to temporary issues. ⏱️
- **Impact:** Users and developers might experience more stable and successful execution of automated tasks, with reduced interruptions from transient errors. 🌟