### PR TITLE
Add lychee --base arg

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -74,7 +74,8 @@ jobs:
 
             rm -rf .lycheecache
             lychee \
-            --scheme 'https' \
+            --base "https://${{ matrix.website }}" \
+            --scheme "https" \
             --timeout 60 \
             --insecure \
             --accept 401,403,429,500,502,999 \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced link checker workflow to improve accuracy and flexibility 🔗✨  

### 📊 Key Changes  
- Updated the link checker to include a `--base` option using `${{ matrix.website }}` for dynamic website base URLs.  
- Maintained other link checking configurations, like `--scheme https` and error code acceptance.  

### 🎯 Purpose & Impact  
- **Purpose**: Improves the accuracy of link checking by dynamically adjusting to the base URL of the target website, avoiding false positives or issues caused by static URLs.  
- **Impact**: Ensures more reliable documentation validation, reduces manual debugging efforts, and enhances the overall quality of published docs 🚀✅.