### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Dependabot for package version updates
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralics website domain checks
 
 name: Check Domains

--- a/.github/workflows/download_websites.yml
+++ b/.github/workflows/download_websites.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Action to download Ultralytics website and docs in parallel
 
 name: Download Websites

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 401(Vimeo, 'unauthorized')

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 401(Vimeo, 'unauthorized')

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Submit Sitemaps to Google Search Console after Pages Deployment
 
 name: Submit Sitemaps

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
 on:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically publishes a new repository tag and release
 


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated licensing headers across workflow files to use a standardized format linking to the official Ultralytics licensing page.  

### 📊 Key Changes  
- Unified header format in multiple GitHub workflow files (e.g., `check_domains.yml`, `download_websites.yml`, etc.).  
- Changed text from variations of "AGPL-3.0 License" to a standardized:  
  `Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`.  

### 🎯 Purpose & Impact  
- 🚀 **Clarifies license terms:** A direct link to the licensing page ensures accessibility and transparency for contributors and users.  
- 🛠️ **Maintains consistency:** Standardizing file headers improves codebase readability and professionalism across the project.  
- ✅ **Improves legal clarity:** Provides a clear and consistent connection to the Ultralytics licensing terms for future reference.