### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,10 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,10 +1,12 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
+
 permissions:
   contents: read
   issues: write
   pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/docs/security/code-scanning/8](https://github.com/ultralytics/docs/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with issues and pull requests, the permissions should include `issues: write` and `pull-requests: write`. Additionally, `contents: read` is required for basic repository access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`stale`) to limit permissions to that job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub workflow permissions for managing stale issues and pull requests. 🔒✨

### 📊 Key Changes
- Added explicit permissions to the "Close stale issues" workflow:
  - Read access to repository contents
  - Write access to issues
  - Write access to pull requests

### 🎯 Purpose & Impact
- Enhances security by clearly defining what the workflow can access and modify.
- Ensures the workflow can properly close stale issues and pull requests without permission errors.
- Provides better maintainability and transparency for repository automation.