### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/download_websites.yml
+++ b/.github/workflows/download_websites.yml
@@ -4,6 +4,9 @@
 
 name: Download Websites
 
+permissions:
+  contents: none
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/docs/security/code-scanning/2](https://github.com/ultralytics/docs/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only downloads websites and does not interact with GitHub resources, the permissions can be set to `none`. This ensures that the workflow does not have unnecessary access to the repository or other GitHub resources.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This is the most straightforward and effective way to address the issue without altering the functionality of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
