### PR TITLE
Fix download_websites.yml trailing backslash

### DIFF
--- a/.github/workflows/download_websites.yml
+++ b/.github/workflows/download_websites.yml
@@ -38,5 +38,5 @@ jobs:
             --reject "*.jpg*,*.jpeg*,*.png*,*.gif*,*.webp*,*.svg*,*.avif*,*.txt,*.ico*,*.bmp*,*.tiff*,*.tif*,*.psd*,*.raw*,*.heic*,*.jfif*,*.webm*,*.mp4*,*.mov*,*.wmv*,*.flv*,*.avi*,*.mkv*" \
             --wait=0.5 \
             --random-wait \
-            --reject-regex '/(zh|ko|ja|ru|de|fr|es|pt|ar|tr|vi|it)/.*|(embedly\.com|youtube\.com)'
+            --reject-regex '/(zh|ko|ja|ru|de|fr|es|pt|ar|tr|vi|it)/.*|(embedly\.com|youtube\.com)' \
             ${{ matrix.url }}


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor update to the website download workflow for improved reliability and clarity. ⚙️✨

### 📊 Key Changes  
- Adjusted the GitHub Actions workflow script by adding a backslash (`\`) for line continuation in the command that downloads website content.

### 🎯 Purpose & Impact  
- 🛠️ Ensures the script runs correctly by properly continuing the command across lines.
- 🚀 Improves workflow reliability, reducing the risk of errors during automated website downloads.
- 👩‍💻 No impact on end users, but helps maintainers keep documentation processes smooth and error-free.