### PR TITLE
Exclude fda.gov from link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -136,7 +136,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|.*\.run\.app|.*\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \            
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|.*\.run\.app|.*\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path '**/ci.yaml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updates the link-checking GitHub Action to ignore FDA website links, reducing false failures in documentation CI ✅

### 📊 Key Changes
- Expanded the exclusion list in .github/workflows/links.yml to include fda.gov alongside existing domains (e.g., LinkedIn, X/Twitter, Google Fonts).
- No content or docs visible changes—only CI configuration is updated.

### 🎯 Purpose & Impact
- Prevents flaky CI runs caused by unreliable or rate-limited fda.gov link checks 🚫🔗
- Speeds up and stabilizes documentation PR validations, improving developer and contributor experience ⚡
- Ensures smoother merges with fewer manual retries or overrides 🧩