### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,8 @@
 #   - 999(LinkedIn, 'unknown status code')
 
 name: Website links and spellcheck
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,7 @@
 #   - 999(LinkedIn, 'unknown status code')
 
 name: Website links and spellcheck
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/docs/security/code-scanning/3](https://github.com/ultralytics/docs/security/code-scanning/3)

To resolve the problem, we should add an explicit `permissions` block at an appropriate place in `.github/workflows/links.yml`, limiting GitHub token access for this workflow to the minimal required. Best practice is to add it at the root level so it applies to all jobs unless overridden; in this case, the workflow only has one job, so either at the root-level or the job-level is sufficient. The steps do not require write access to repository contents, but may need `contents: read` for general access. Since there are no operations to create issues, pull requests, or modify the repository, a restrictive block such as `permissions: contents: read` is suitable. 

To implement the fix, insert the following after the `name:` field and before the `on:` field in `.github/workflows/links.yml`:

```yaml
permissions:
  contents: read
```

This ensures that the workflow and its jobs will only have read access to repository contents via the `GITHUB_TOKEN`, following least-privilege principles.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Sets explicit, read-only permissions for the “Website links and spellcheck” GitHub Actions workflow to improve security and clarity 🔒✅

### 📊 Key Changes
- Adds `permissions: contents: read` to `.github/workflows/links.yml`

### 🎯 Purpose & Impact
- Enhances security by applying least-privilege access to the workflow 🔐
- Reduces risk of unintended repository modifications during CI runs 🛡️
- Aligns with GitHub’s recommended best practices and org policy compliance 📏
- No user-facing changes; documentation site behavior remains the same 🌐