### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,8 @@
 # This workflow automatically publishes a new repository tag and release
 
 name: Tag and Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,7 @@
 # This workflow automatically publishes a new repository tag and release
 
 name: Tag and Release
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/docs/security/code-scanning/9](https://github.com/ultralytics/docs/security/code-scanning/9)

To fix the problem, add a `permissions` block to the root of the workflow file (`.github/workflows/tag.yml`) specifying the minimum required privileges to execute the actions (creating/pushing tags, making releases). For pushing tags and creating releases, the workflow needs `contents: write`. We will add the following block right after the `name:` line and before the `on:` line to minimize disruption and set the effective permissions for all jobs in this workflow. No additional methods, imports, or libraries are required—this is a declarative YAML setting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Grants the “Tag and Release” GitHub Actions workflow explicit write access so it can successfully create tags and releases. 🚀

### 📊 Key Changes
- Added `permissions: contents: write` to `.github/workflows/tag.yml`.

### 🎯 Purpose & Impact
- Ensures the workflow can create repository tags and releases without failing due to insufficient permissions. ✅
- Aligns with GitHub’s recommended least-privilege model for workflows, improving clarity and security. 🔒
- Results in more reliable, automated releases for the docs repo; no changes required from end users. 📦

For more details on workflow permissions, see GitHub’s documentation on [Workflow permissions for GITHUB_TOKEN](https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).