### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -10,6 +10,8 @@
 #   - 999(LinkedIn, 'unknown status code')
 
 name: Check Broken Repo links
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/docs/security/code-scanning/11](https://github.com/ultralytics/docs/security/code-scanning/11)

The best fix is to explicitly set a minimal `permissions` block in the workflow file. For workflows that only need to read repository content (such as for link-checking, file scanning, or CI validation), `contents: read` suffices. Since the workflow does not interact with issues or pull requests in a write capacity, no `write` permissions are needed. Add the following block just under `name: Check Broken Repo links`, before the `on:` block (as workflow-level permissions). This will ensure all jobs and steps in the workflow use only the minimal permissions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
