### PR TITLE
Update links.yml to accept 504

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -137,7 +137,7 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,401,403,429,500,502,999 \
+            --accept 100..=103,200..=299,401,403,429,500,502,504,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|.*\.run\.app|.*\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \


### PR DESCRIPTION
@miles-deans-ultralytics should reduce 504 false positives

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Accepts HTTP 504 (Gateway Timeout) in docs link-checking CI to reduce false failures and keep documentation pipelines green ✅

### 📊 Key Changes
- Updated link checker workflow to treat HTTP 504 as an acceptable status alongside existing codes (e.g., 200–299, 401, 403, 429, 500, 502, 999) 🔧
- No other rules or exclusions changed in the CI link-check step 🔒

### 🎯 Purpose & Impact
- Fewer flaky CI failures caused by transient gateway timeouts on external sites 🌐
- Smoother, faster docs PR reviews and merges 🚀
- Minor trade-off: genuine 504 issues on external links may be temporarily overlooked; relies on future runs or manual checks to catch persistent outages ⚠️