### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/check_domains.yml

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - name: Install dependencies
         run: uv pip install --system requests
       - name: Check domain redirections


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/check_domains.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions setup for the docs repository by upgrading `astral-sh/setup-uv` from `v7` to `v8` in the domain-check workflow.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/check_domains.yml`
- Changed:
  - `astral-sh/setup-uv@v7` → `astral-sh/setup-uv@v8`
- No changes to the domain-check logic itself; this is a workflow maintenance update 🛠️

### 🎯 Purpose & Impact
- Keeps the CI workflow aligned with the latest supported version of the `setup-uv` action ✅
- Helps improve long-term reliability and maintainability of the docs automation
- Reduces the risk of issues from using older action versions in GitHub workflows
- Has little to no direct user-facing impact, but supports smoother internal checks for documentation domain redirections 🌐