### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/links.yml

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install lychee and dependencies
         run: |


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/links.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates the GitHub Actions link-checking workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the docs CI setup current.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/links.yml`
- Changed the action version from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`
- No content or documentation pages were changed; this is a maintenance update to the automation workflow ⚙️

### 🎯 Purpose & Impact
- Helps keep the docs repository’s CI workflows aligned with the latest supported version of the `setup-uv` action ✅
- May improve reliability, compatibility, or security for the automated link-checking process 🔒
- Reduces the risk of future workflow issues caused by using an outdated action version 🚀
- Has little to no direct impact on end users reading the docs, but helps maintain healthy documentation infrastructure behind the scenes 🛠️