### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/sitemaps.yml

### DIFF
--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install Dependencies
         run: uv pip install --system google-api-python-client oauth2client packaging


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/sitemaps.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use a newer version of `astral-sh/setup-uv`, improving the docs repository’s sitemap automation setup.

### 📊 Key Changes
- Upgraded the GitHub Action in `.github/workflows/sitemaps.yml` from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`.
- No changes were made to sitemap logic, content generation, or deployment steps.
- The update is limited to the CI workflow dependency used during sitemap-related automation.

### 🎯 Purpose & Impact
- ✅ Keeps the docs CI workflow current with the latest supported `setup-uv` action version.
- 🛠️ May improve reliability, compatibility, and maintenance of automated sitemap generation.
- 📦 Helps reduce risk from using older action versions in GitHub workflows.
- 👀 For most users, there is no direct visible change, but it supports smoother behind-the-scenes docs infrastructure.