### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/tag.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions setup in `ultralytics/docs` to use `astral-sh/setup-uv@v8` instead of `@v7`.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/tag.yml`
- Changed the action version from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`
- No documentation content or user-facing docs pages were modified

### 🎯 Purpose & Impact
- Improves CI/CD maintenance by keeping the tagging workflow aligned with the latest `setup-uv` action release 🛠️
- May bring upstream fixes, compatibility improvements, or performance enhancements from `v8`
- Helps reduce the risk of using an outdated workflow dependency in automated release/tag processes ✅
- Minimal end-user impact, but beneficial for repository reliability and long-term upkeep 📦