### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - name: Install dependencies
         run: uv pip install --system requests
       - name: Check domain redirections

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install lychee and dependencies
         run: |

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install Dependencies
         run: uv pip install --system google-api-python-client oauth2client packaging

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates several GitHub Actions workflows in `ultralytics/docs` to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping CI tooling current and more maintainable.

### 📊 Key Changes
- ⬆️ Upgraded `astral-sh/setup-uv` from `v7` to `v8` in multiple GitHub Actions workflows.
- 🧪 Updated the dependency setup step in `check_domains.yml`, which validates domain redirects.
- 🔗 Updated the same action in `links.yml`, which checks for broken links.
- 🗺️ Updated `sitemaps.yml`, which handles sitemap-related automation.
- 🏷️ Updated `tag.yml`, which supports tagging and release-related workflow steps.
- 🛠️ No documentation content or user-facing site pages were changed; this is a CI/CD maintenance update.

### 🎯 Purpose & Impact
- ✅ Keeps the docs repository aligned with the latest supported version of the `setup-uv` GitHub Action.
- 🔒 Helps improve workflow reliability, compatibility, and long-term maintainability.
- 🚀 Reduces the risk of issues caused by using older CI tooling versions.
- 👩‍💻 Has little to no direct impact on end users reading the docs, but it helps maintainers by keeping automation healthy and up to date.