### PR TITLE
Fix redirected URLs

### DIFF
--- a/docs/en/compare/damo-yolo-vs-efficientdet.md
+++ b/docs/en/compare/damo-yolo-vs-efficientdet.md
@@ -87,7 +87,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/efficientdet-vs-damo-yolo.md
+++ b/docs/en/compare/efficientdet-vs-damo-yolo.md
@@ -91,7 +91,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose DAMO-YOLO
 

--- a/docs/en/compare/efficientdet-vs-rtdetr.md
+++ b/docs/en/compare/efficientdet-vs-rtdetr.md
@@ -99,7 +99,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose RT-DETR
 

--- a/docs/en/compare/efficientdet-vs-yolo26.md
+++ b/docs/en/compare/efficientdet-vs-yolo26.md
@@ -104,7 +104,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLO26
 

--- a/docs/en/compare/efficientdet-vs-yolov10.md
+++ b/docs/en/compare/efficientdet-vs-yolov10.md
@@ -115,7 +115,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOv10
 

--- a/docs/en/compare/efficientdet-vs-yolov6.md
+++ b/docs/en/compare/efficientdet-vs-yolov6.md
@@ -91,7 +91,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOv6
 

--- a/docs/en/compare/efficientdet-vs-yolov7.md
+++ b/docs/en/compare/efficientdet-vs-yolov7.md
@@ -93,7 +93,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOv7
 

--- a/docs/en/compare/efficientdet-vs-yolov8.md
+++ b/docs/en/compare/efficientdet-vs-yolov8.md
@@ -117,7 +117,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOv8
 

--- a/docs/en/compare/efficientdet-vs-yolov9.md
+++ b/docs/en/compare/efficientdet-vs-yolov9.md
@@ -86,7 +86,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOv9
 

--- a/docs/en/compare/efficientdet-vs-yolox.md
+++ b/docs/en/compare/efficientdet-vs-yolox.md
@@ -91,7 +91,7 @@ EfficientDet is a strong choice for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose YOLOX
 

--- a/docs/en/compare/pp-yoloe-vs-efficientdet.md
+++ b/docs/en/compare/pp-yoloe-vs-efficientdet.md
@@ -90,7 +90,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/rtdetr-vs-damo-yolo.md
+++ b/docs/en/compare/rtdetr-vs-damo-yolo.md
@@ -92,7 +92,7 @@ results_yolo[0].show()
 
 Choosing between these architectures depends entirely on your specific project requirements:
 
-- **RTDETRv2** excels in server-side processing where VRAM is abundant. Its global context awareness is perfect for [medical imaging](https://www.nature.com/subjects/medical-imaging) and dense crowd analysis where occlusions are frequent.
+- **RTDETRv2** excels in server-side processing where VRAM is abundant. Its global context awareness is perfect for [medical imaging](https://www.nature.com/subjects/medical-imaging?error=cookies_not_supported&code=fe3dedd7-5a9d-4206-9baf-f97b0ad990aa) and dense crowd analysis where occlusions are frequent.
 - **DAMO-YOLO** is highly suitable for [embedded IoT applications](https://en.wikipedia.org/wiki/Internet_of_things) and fast-moving industrial inspection lines where low parameter counts and high FPS are strict requirements.
 
 ## The Future: Ultralytics YOLO26

--- a/docs/en/compare/rtdetr-vs-efficientdet.md
+++ b/docs/en/compare/rtdetr-vs-efficientdet.md
@@ -97,7 +97,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/yolo11-vs-efficientdet.md
+++ b/docs/en/compare/yolo11-vs-efficientdet.md
@@ -140,7 +140,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/yolo26-vs-yolov7.md
+++ b/docs/en/compare/yolo26-vs-yolov7.md
@@ -107,7 +107,7 @@ YOLO26 is the undisputed recommendation for modern, forward-looking computer vis
 
 While mostly superseded by newer architectures, YOLOv7 retains specific niche utilities.
 
-- **Academic Benchmarking:** Researchers developing new anchor-based detection heads or studying gradient path strategies frequently use YOLOv7 as a standard baseline comparison on platforms like [Papers With Code](https://huggingface.co/papers/trending).
+- **Academic Benchmarking:** Researchers developing new anchor-based detection heads or studying gradient path strategies frequently use YOLOv7 as a standard baseline comparison on platforms like Papers With Code.
 - **Legacy GPU Pipelines:** Enterprise systems that were custom-built around YOLOv7's specific tensor outputs and custom NMS configurations on powerful [AWS EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instances may delay migration to newer models until a total system refactor is necessary.
 
 ## Code Example: Getting Started

--- a/docs/en/compare/yolo26-vs-yolov7.md
+++ b/docs/en/compare/yolo26-vs-yolov7.md
@@ -107,7 +107,7 @@ YOLO26 is the undisputed recommendation for modern, forward-looking computer vis
 
 While mostly superseded by newer architectures, YOLOv7 retains specific niche utilities.
 
-- **Academic Benchmarking:** Researchers developing new anchor-based detection heads or studying gradient path strategies frequently use YOLOv7 as a standard baseline comparison on platforms like [Papers With Code](https://paperswithcode.com/).
+- **Academic Benchmarking:** Researchers developing new anchor-based detection heads or studying gradient path strategies frequently use YOLOv7 as a standard baseline comparison on platforms like [Papers With Code](https://huggingface.co/papers/trending).
 - **Legacy GPU Pipelines:** Enterprise systems that were custom-built around YOLOv7's specific tensor outputs and custom NMS configurations on powerful [AWS EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instances may delay migration to newer models until a total system refactor is necessary.
 
 ## Code Example: Getting Started

--- a/docs/en/compare/yolo26-vs-yolov9.md
+++ b/docs/en/compare/yolo26-vs-yolov9.md
@@ -110,7 +110,7 @@ Choosing a model involves more than just reading an accuracy benchmark; the surr
 
 ### Ease of Use and Ecosystem
 
-The [Ultralytics Python API](https://docs.ultralytics.com/usage/python/) offers a seamless "zero-to-hero" experience. Instead of cloning complex repositories or manually configuring distributed training scripts, developers can install the package via `pip` and start training immediately. The actively maintained [Ultralytics ecosystem](https://platform.ultralytics.com/deploy/inference/) guarantees frequent updates, automated integrations with ML platforms like [Weights & Biases](https://wandb.ai/), and extensive documentation.
+The [Ultralytics Python API](https://docs.ultralytics.com/usage/python/) offers a seamless "zero-to-hero" experience. Instead of cloning complex repositories or manually configuring distributed training scripts, developers can install the package via `pip` and start training immediately. The actively maintained [Ultralytics ecosystem](https://platform.ultralytics.com/deploy/inference/) guarantees frequent updates, automated integrations with ML platforms like [Weights & Biases](https://wandb.ai/site), and extensive documentation.
 
 !!! note "Other Ultralytics Models"
 

--- a/docs/en/compare/yolov10-vs-efficientdet.md
+++ b/docs/en/compare/yolov10-vs-efficientdet.md
@@ -119,7 +119,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/yolov10-vs-yolov5.md
+++ b/docs/en/compare/yolov10-vs-yolov5.md
@@ -106,7 +106,7 @@ For most new projects, [Ultralytics YOLO26](https://docs.ultralytics.com/models/
 While YOLOv10 offers excellent detection capabilities, relying on academic repositories can sometimes complicate production pipelines. By using the official [Ultralytics Python package](https://pypi.org/project/ultralytics/), you gain access to a unified ecosystem that supports both YOLOv5 and YOLOv10, along with advanced features.
 
 - **Training Efficiency:** Ultralytics YOLO architectures are deeply optimized for lower [memory requirements](https://docs.ultralytics.com/guides/yolo-performance-metrics/) during training. Unlike heavy transformer models (such as RT-DETR) which require massive CUDA memory, you can comfortably train YOLOv5 and YOLOv10 on standard consumer GPUs.
-- **Ecosystem Integration:** The integration with [Ultralytics Platform](https://platform.ultralytics.com) allows developers to visually manage datasets, track experiments using [Weights & Biases](https://wandb.ai/), and automatically tune hyperparameters.
+- **Ecosystem Integration:** The integration with [Ultralytics Platform](https://platform.ultralytics.com) allows developers to visually manage datasets, track experiments using [Weights & Biases](https://wandb.ai/site), and automatically tune hyperparameters.
 
 ### Code Example: Seamless Training
 

--- a/docs/en/compare/yolov5-vs-yolov8.md
+++ b/docs/en/compare/yolov5-vs-yolov8.md
@@ -103,7 +103,7 @@ The data reveals that YOLOv8 provides a substantial boost in accuracy. For insta
 
 ## The Ecosystem Advantage
 
-Choosing either YOLOv5 or YOLOv8 grants developers access to the well-maintained [Ultralytics Platform](https://platform.ultralytics.com/). This integrated environment offers simple tools for dataset annotation, [hyperparameter tuning](https://docs.ultralytics.com/guides/hyperparameter-tuning/), cloud training, and model monitoring. The active development and strong community support ensure that developers can quickly resolve issues and integrate with external tools like [Weights & Biases](https://wandb.ai/) and [ClearML](https://clear.ml/).
+Choosing either YOLOv5 or YOLOv8 grants developers access to the well-maintained [Ultralytics Platform](https://platform.ultralytics.com/). This integrated environment offers simple tools for dataset annotation, [hyperparameter tuning](https://docs.ultralytics.com/guides/hyperparameter-tuning/), cloud training, and model monitoring. The active development and strong community support ensure that developers can quickly resolve issues and integrate with external tools like [Weights & Biases](https://wandb.ai/site) and [ClearML](https://clear.ml/).
 
 While other frameworks might suffer from steep learning curves, Ultralytics prioritizes a streamlined user experience, ensuring a favorable trade-off between speed and accuracy suitable for diverse real-world deployment scenarios.
 

--- a/docs/en/compare/yolov6-vs-efficientdet.md
+++ b/docs/en/compare/yolov6-vs-efficientdet.md
@@ -120,7 +120,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 

--- a/docs/en/compare/yolov7-vs-yolo26.md
+++ b/docs/en/compare/yolov7-vs-yolo26.md
@@ -26,7 +26,7 @@ Introduced in mid-2022, YOLOv7 pushed the boundaries of what was possible on GPU
 - **GitHub:** [WongKinYiu/yolov7](https://github.com/WongKinYiu/yolov7)
 - **Docs:** [Ultralytics YOLOv7 Documentation](https://docs.ultralytics.com/models/yolov7/)
 
-YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive [state-of-the-art benchmark on COCO](https://paperswithcode.com/sota/object-detection-on-coco) at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, which can introduce latency bottlenecks during deployment.
+YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive [state-of-the-art benchmark on COCO](https://huggingface.co/papers/trending) at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, which can introduce latency bottlenecks during deployment.
 
 [Learn more about YOLOv7](https://docs.ultralytics.com/models/yolov7/){ .md-button }
 

--- a/docs/en/compare/yolov7-vs-yolo26.md
+++ b/docs/en/compare/yolov7-vs-yolo26.md
@@ -26,7 +26,7 @@ Introduced in mid-2022, YOLOv7 pushed the boundaries of what was possible on GPU
 - **GitHub:** [WongKinYiu/yolov7](https://github.com/WongKinYiu/yolov7)
 - **Docs:** [Ultralytics YOLOv7 Documentation](https://docs.ultralytics.com/models/yolov7/)
 
-YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive [state-of-the-art benchmark on COCO](https://huggingface.co/papers/trending) at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, which can introduce latency bottlenecks during deployment.
+YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive state-of-the-art benchmark on COCO at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, which can introduce latency bottlenecks during deployment.
 
 [Learn more about YOLOv7](https://docs.ultralytics.com/models/yolov7/){ .md-button }
 

--- a/docs/en/compare/yolov7-vs-yolov8.md
+++ b/docs/en/compare/yolov7-vs-yolov8.md
@@ -101,7 +101,7 @@ predictions[0].show()
 
 !!! note "Experiment Tracking"
 
-    YOLOv8 integrates natively with popular MLops tools like [Weights & Biases](https://wandb.ai/) and [ClearML](https://docs.ultralytics.com/integrations/clearml/), allowing you to monitor your [hyperparameter tuning](https://docs.ultralytics.com/guides/hyperparameter-tuning/) and training metrics in real-time.
+    YOLOv8 integrates natively with popular MLops tools like [Weights & Biases](https://wandb.ai/site) and [ClearML](https://docs.ultralytics.com/integrations/clearml/), allowing you to monitor your [hyperparameter tuning](https://docs.ultralytics.com/guides/hyperparameter-tuning/) and training metrics in real-time.
 
 ## Ideal Use Cases
 

--- a/docs/en/compare/yolov8-vs-yolov7.md
+++ b/docs/en/compare/yolov8-vs-yolov7.md
@@ -84,7 +84,7 @@ YOLOv7 is primarily a detection model, with experimental branches for other task
 
 Exporting a model for production can often be a bottleneck. The Ultralytics package allows developers to export to formats like [ONNX](https://onnx.ai/), [TensorRT](https://developer.nvidia.com/tensorrt), and CoreML with a single line of Python code. This avoids the operator support issues sometimes encountered when exporting complex anchor-based graphs.
 
-Furthermore, YOLOv8 integrates seamlessly with MLOps tools. Whether you are tracking experiments with [Weights & Biases](https://wandb.ai/) or testing deployments on [Hugging Face Spaces](https://huggingface.co/), the Ultralytics ecosystem handles the heavy lifting.
+Furthermore, YOLOv8 integrates seamlessly with MLOps tools. Whether you are tracking experiments with [Weights & Biases](https://wandb.ai/site) or testing deployments on [Hugging Face Spaces](https://huggingface.co/), the Ultralytics ecosystem handles the heavy lifting.
 
 ### Code Example: Training and Exporting YOLOv8
 
@@ -123,7 +123,7 @@ The architectural differences between the two models dictate their ideal deploym
 
 **When to Consider YOLOv7:**
 
-- **Academic Benchmarking:** Researchers studying the effects of re-parameterization techniques often use YOLOv7 as a standard baseline, as reflected by its popularity on [Papers With Code](https://paperswithcode.com/).
+- **Academic Benchmarking:** Researchers studying the effects of re-parameterization techniques often use YOLOv7 as a standard baseline, as reflected by its popularity on [Papers With Code](https://huggingface.co/papers/trending).
 - **Legacy Server Pipelines:** If an existing heavy-compute pipeline is already strictly optimized around YOLOv7's specific anchor outputs, maintaining it might be practical in the short term.
 
 ## Looking Ahead: The Next Generation

--- a/docs/en/compare/yolox-vs-efficientdet.md
+++ b/docs/en/compare/yolox-vs-efficientdet.md
@@ -102,7 +102,7 @@ EfficientDet is recommended for:
 
 - **Google Cloud and TPU Pipelines:** Systems deeply integrated with Google Cloud Vision APIs or TPU infrastructure where EfficientDet has native optimization.
 - **Compound Scaling Research:** Academic benchmarking focused on studying the effects of balanced network depth, width, and resolution scaling.
-- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://www.tensorflow.org/lite) export for Android or embedded Linux devices.
+- **Mobile Deployment via TFLite:** Projects that specifically require [TensorFlow Lite](https://ai.google.dev/edge/litert) export for Android or embedded Linux devices.
 
 ### When to Choose Ultralytics (YOLO26)
 


### PR DESCRIPTION
## Summary
- update redirected external URLs to their final destinations
- apply the redirect cleanup across tracked documentation and related text files

## Testing
- no tests run (link-only changes)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR refreshes and standardizes external links across multiple model comparison docs, mainly updating TensorFlow Lite and Weights & Biases references for better accuracy and maintenance.

### 📊 Key Changes
- Updated many **EfficientDet comparison pages** to replace old **TensorFlow Lite** links with the newer Google AI LiteRT/TFLite destination 📱
- Changed several **Weights & Biases** links from the root domain to the more specific `wandb.ai/site` page 🛠️
- Removed or simplified a few external links where needed, such as replacing linked text like **Papers With Code** with plain text in one case ✏️
- Adjusted some other external references, including:
  - a **medical imaging** link in the RT-DETR vs DAMO-YOLO comparison
  - a **Papers With Code/trending papers** style link in a YOLOv7/YOLOv8 comparison page 🌐
- Changes affect a wide set of files under `docs/en/compare/`, especially pages comparing **EfficientDet** with YOLO models and other detectors 📚

### 🎯 Purpose & Impact
- Improves the **reliability of documentation links**, helping users reach current external resources instead of outdated pages ✅
- Reduces friction for readers exploring deployment tools, MLOps integrations, and related technologies 🚀
- Keeps the docs ecosystem more **consistent and maintainable** across many comparison pages 🔄
- Impact is mostly **documentation quality only**: no model behavior, training code, or product features were changed 🧾
- Users may notice smoother navigation, though a few updated external links should be double-checked to ensure they point to the most appropriate destination 🔍