### PR TITLE
Remove uv setup warnings from domain check workflow

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.14"
       - name: Install dependencies
         run: python -m pip install requests
       - name: Check domain redirections

--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -65,9 +65,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv pip install --system requests
+        run: python -m pip install requests
       - name: Check domain redirections
         shell: python
         run: |


### PR DESCRIPTION
## Summary
- remove `astral-sh/setup-uv` from `check_domains.yml`
- install `requests` with `python -m pip` instead

## Why
`setup-uv` is the source of the repeated cache, dependency-glob, and empty-workdir warnings in this workflow. This job only needs Python and `requests`, so `uv` is unnecessary here.

## Testing
- `python3 -m pip --version`
- `git diff --check -- .github/workflows/check_domains.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR simplifies the domain-checking GitHub Action by removing `uv` setup and switching to a direct `pip` install on Python 3.14.

### 📊 Key Changes
- Updated the **GitHub Actions workflow** in `.github/workflows/check_domains.yml`.
- Changed the Python setup from a floating version (`3.x`) to a fixed version: **Python 3.14**.
- Removed the `astral-sh/setup-uv` step entirely.
- Replaced `uv pip install --system requests` with a standard `python -m pip install requests`.

### 🎯 Purpose & Impact
- ✅ **Simpler CI workflow**: Fewer setup steps make the action easier to understand and maintain.
- ⚡ **Reduced dependency on extra tooling**: Removing `uv` lowers complexity and avoids relying on an additional package manager for a very small install.
- 🔒 **More predictable runs**: Pinning to Python 3.14 helps ensure consistent behavior across workflow executions.
- 👥 **Low user-facing impact**: This is mainly an internal documentation/CI maintenance improvement, but it can make automated checks more reliable for contributors.