### PR TITLE
Preserve fixed retry delay in links workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -168,6 +168,7 @@ jobs:
         with:
           retry_delay_seconds: 1800
           retries: 3
+          backoff: fixed
           run: |
             # Count successfully downloaded files
             downloaded_files=$(find ${{ matrix.website }} -type f | wc -l)


### PR DESCRIPTION
## Summary
Preserves the previous fixed 30-minute retry spacing in the links workflow after ultralytics/actions/retry switched to exponential backoff with jitter by default.

## Changes
- add backoff: fixed to the retry-wrapped download step in .github/workflows/links.yml

## Why
Without an explicit override, the second and third retries can expand beyond the intended 30-minute spacing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the link-checking GitHub Actions workflow to use a fixed retry backoff, making documentation link checks more predictable and stable.

### 📊 Key Changes
- Added `backoff: fixed` to the `.github/workflows/links.yml` workflow.
- This change affects the retry behavior for the link-checking job when it encounters failures.
- The workflow still keeps the existing retry count and delay settings, but now retries happen with a consistent interval instead of a varying backoff pattern.

### 🎯 Purpose & Impact
- Improves reliability of automated link validation for the `ultralytics/docs` repository 🔗
- Makes retry timing more predictable, which can help when failures are caused by temporary external issues like slow websites or network hiccups ⏱️
- May reduce unexpected delays in CI runs and make troubleshooting easier for maintainers 🧪
- Helps keep documentation quality high by ensuring broken-link checks run more consistently 📚