### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: needs.Test.result == 'failure' && github.repository == 'ultralytics/docs' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Notify Slack for broken links
         if: always() && steps.lychee.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -239,7 +239,7 @@ jobs:
 
       - name: Notify Slack for spelling errors
         if: always() && steps.codespell.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -248,7 +248,7 @@ jobs:
 
       - name: Notify Slack for large images
         if: always() && steps.image_sizes.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the Slack GitHub Action version used in docs repository workflows from `v3.0.1` to `v3.0.2` to keep automated notifications current and reliable.

### 📊 Key Changes
- ⬆️ Upgraded `slackapi/slack-github-action` from `v3.0.1` to `v3.0.2` in `.github/workflows/check_domains.yml`.
- ⬆️ Updated the same Slack action in `.github/workflows/links.yml` for:
  - broken link alerts
  - spelling error alerts
  - large image alerts
- 🔔 No workflow logic, conditions, or notification targets were changed—only the Slack action version was bumped.

### 🎯 Purpose & Impact
- 🛠️ Keeps GitHub Actions dependencies up to date, which helps maintain compatibility and stability.
- 🔒 May include upstream fixes or minor improvements from the Slack action maintainers, reducing the risk of notification issues.
- 📣 Helps ensure the Ultralytics docs team continues receiving alerts for domain failures, broken links, spelling issues, and oversized images.
- ✅ Low-risk maintenance change with little to no visible impact for end users, but useful for smoother internal docs operations.