### PR TITLE
Fix lychee install workflows

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Install lychee and dependencies
         run: |
-          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xz -C /usr/local/bin
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
+            sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
           uv pip install --system -r requirements.txt
 
       - name: Get Website URLs

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install lychee
-        run: curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xz -C /usr/local/bin
+        run: |
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
+            sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
       - name: Test Markdown and HTML links with retry
         uses: ultralytics/actions/retry@main


### PR DESCRIPTION
## Summary\n- Extract the lychee binary from the nested release archive path in both link workflows\n- Match the working handbook install command pattern\n\n## Tests\n- actionlint -ignore SC2004 -ignore SC2086 -ignore SC2129 .github/workflows/links.yml .github/workflows/links_local.yml\n- git diff --check -- .github/workflows/links.yml .github/workflows/links_local.yml\n- Verified latest lychee archive contains lychee-x86_64-unknown-linux-gnu/lychee\n\nNote: plain actionlint still reports pre-existing ShellCheck warnings in .github/workflows/links.yml unrelated to this change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR improves the docs link-checking workflows by fixing how the `lychee` link checker is installed in GitHub Actions, making CI runs more reliable.

### 📊 Key Changes
- Updated the `lychee` installation step in both `.github/workflows/links.yml` and `.github/workflows/links_local.yml`.
- Changed the extraction command to unpack only the `lychee` binary from the downloaded archive instead of extracting the full archive directly into `/usr/local/bin`.
- Added `--strip-components=1` so the binary is placed in the correct location without nested folders.
- Kept the rest of the link-checking workflow unchanged, including dependency installation and local/remote link validation steps.

### 🎯 Purpose & Impact
- ✅ Fixes a workflow setup issue that could prevent the link checker from being installed correctly.
- 🚀 Makes automated link validation more dependable for the `ultralytics/docs` repository.
- 🛠️ Reduces CI failures caused by archive structure differences, helping contributors and maintainers catch real broken links instead of setup errors.
- 📚 Improves the overall stability of documentation quality checks, which supports a smoother docs publishing process.