### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: needs.Test.result == 'failure' && github.repository == 'ultralytics/docs' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Notify Slack for broken links
         if: always() && steps.lychee.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -248,7 +248,7 @@ jobs:
 
       - name: Notify Slack for spelling errors
         if: always() && steps.codespell.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -257,7 +257,7 @@ jobs:
 
       - name: Notify Slack for large images
         if: always() && steps.image_sizes.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the GitHub Slack notification action from `v3.0.2` to `v3.0.3` across docs CI workflows to keep automated alerts current and reliable.

### 📊 Key Changes
- Upgraded `slackapi/slack-github-action` from `v3.0.2` to `v3.0.3` in `.github/workflows/check_domains.yml`.
- Updated the same Slack action version in `.github/workflows/links.yml` for:
  - broken link notifications 🔗
  - spelling error notifications ✍️
  - large image warnings 🖼️
- No workflow logic, conditions, or notification targets were changed—only the Slack action version was bumped.

### 🎯 Purpose & Impact
- Helps keep GitHub Actions dependencies up to date ✅
- Reduces risk of issues tied to older action versions, improving CI maintenance and stability 🛠️
- Ensures Slack alerts for docs/site problems continue working smoothly for scheduled and push-based checks 📣
- Low-risk change for users and contributors, since it does not alter how checks behave—only the underlying notification action 🚀