### PR TITLE
Add Academy and Handbook sitemap submissions

### DIFF
--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -63,8 +63,10 @@ jobs:
                 webmasters_service = build('webmasters', 'v3', credentials=credentials)
                 webmasters_service.sitemaps().submit(siteUrl=site_url, feedpath=sitemap_url).execute()
                 print(f'Submitted {sitemap_url} ✅')
+                return True
               except Exception as e:
                 print(f'ERROR ❌: {sitemap_url} failed to submit {e}')
+                return False
           credentials_json = os.environ['CREDENTIALS_JSON']
           sitemap_paths = {
               "www.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
@@ -72,10 +74,14 @@ jobs:
               "academy.ultralytics.com": [''],
               "handbook.ultralytics.com": [''],
           }
+          failed_sitemaps = []
           for host, paths in sitemap_paths.items():
               for path in paths:
                   sitemap = f'https://{host}{path}/sitemap.xml'
-                  submit_sitemap(f'https://{host}/', sitemap, credentials_json)
+                  if not submit_sitemap(f'https://{host}/', sitemap, credentials_json):
+                      failed_sitemaps.append(sitemap)
+          if failed_sitemaps:
+              raise SystemExit(f"Failed to submit {len(failed_sitemaps)} sitemap(s): {', '.join(failed_sitemaps)}")
 
       - name: Submit URLs to IndexNow
         env:
@@ -123,8 +129,6 @@ jobs:
           # Submit URLs from each sitemap to IndexNow
           sitemap_paths = {
               "docs.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
-              "academy.ultralytics.com": [''],
-              "handbook.ultralytics.com": [''],
           }
           for host, paths in sitemap_paths.items():
               all_urls = []

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -73,10 +73,11 @@ jobs:
               "docs.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
               "academy.ultralytics.com": [''],
               "handbook.ultralytics.com": [''],
+              "platform.ultralytics.com": [''],
           }
           failed_sitemaps = []
           for host, paths in sitemap_paths.items():
-              site_url = "sc-domain:ultralytics.com" if host in {"academy.ultralytics.com", "handbook.ultralytics.com"} else f"https://{host}/"
+              site_url = "sc-domain:ultralytics.com" if host in {"academy.ultralytics.com", "handbook.ultralytics.com", "platform.ultralytics.com"} else f"https://{host}/"
               for path in paths:
                   sitemap = f'https://{host}{path}/sitemap.xml'
                   if not submit_sitemap(site_url, sitemap, credentials_json):

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           modified_files=$(git diff --name-only HEAD^ HEAD | tr '\n' ' ')
           echo "Modified files: $modified_files"
-          echo "MODIFIED_FILES=$modified_files" >> $GITHUB_ENV
+          echo "MODIFIED_FILES=$modified_files" >> "$GITHUB_ENV"
 
       - name: Submit Sitemaps to Google
         env:
@@ -66,10 +66,15 @@ jobs:
               except Exception as e:
                 print(f'ERROR ❌: {sitemap_url} failed to submit {e}')
           credentials_json = os.environ['CREDENTIALS_JSON']
-          # Submit sitemaps for each language
-          for host in ["www.ultralytics.com", "docs.ultralytics.com"]:
-              for lang in ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it']:
-                  sitemap = f'https://{host}{lang}/sitemap.xml'
+          sitemap_paths = {
+              "www.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
+              "docs.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
+              "academy.ultralytics.com": [''],
+              "handbook.ultralytics.com": [''],
+          }
+          for host, paths in sitemap_paths.items():
+              for path in paths:
+                  sitemap = f'https://{host}{path}/sitemap.xml'
                   submit_sitemap(f'https://{host}/', sitemap, credentials_json)
 
       - name: Submit URLs to IndexNow
@@ -105,32 +110,41 @@ jobs:
                   print(f"ERROR ❌: Failed to extract URLs from {sitemap_url} - {e}")
                   return []
 
-          def filter_modified_urls(urls, modified_files):
+          def filter_modified_urls(host, urls, modified_files):
               # Filter URLs based on modified files
               modified_urls = []
               for file in modified_files:
                   # Convert file path to URL path, i.e. 'modes/index.html' -> 'https://docs.ultralytics.com/modes/'
-                  full_url = f'https://{host}/{file.replace('index.html', '')}'
+                  full_url = f"https://{host}/{file.replace('index.html', '')}"
                   if full_url in urls:
                       modified_urls.append(full_url)
               return modified_urls
 
           # Submit URLs from each sitemap to IndexNow
-          host = "docs.ultralytics.com"
-          all_urls = []
-          for lang in ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it']:
-              sitemap = f'https://{host}{lang}/sitemap.xml'
-              lang_urls = extract_urls_from_sitemap(sitemap)
-              all_urls.extend(lang_urls)
-              print(f'Found {len(lang_urls)} in {sitemap} ({len(all_urls)} total)')
+          sitemap_paths = {
+              "docs.ultralytics.com": ['', '/zh', '/ko', '/ja', '/ru', '/de', '/fr', '/es', '/pt', '/ar', '/tr', '/vi', '/it'],
+              "academy.ultralytics.com": [''],
+              "handbook.ultralytics.com": [''],
+          }
+          for host, paths in sitemap_paths.items():
+              all_urls = []
+              for path in paths:
+                  sitemap = f'https://{host}{path}/sitemap.xml'
+                  sitemap_urls = extract_urls_from_sitemap(sitemap)
+                  all_urls.extend(sitemap_urls)
+                  print(f'Found {len(sitemap_urls)} in {sitemap} ({len(all_urls)} total)')
 
-          # Filter URLs based on modified files
-          if os.getenv('SUBMIT_ALL_URLS', 'false').lower() == 'true':
-              urls_to_submit = all_urls
-          else:
-              urls_to_submit = filter_modified_urls(all_urls, os.environ['MODIFIED_FILES'].split())
-              print(f'\nFound {len(urls_to_submit)} URLs updated in last commit to submit:\n{"\n".join(urls_to_submit)}\n')
+              # Filter URLs based on modified files
+              if os.getenv('SUBMIT_ALL_URLS', 'false').lower() == 'true':
+                  urls_to_submit = all_urls
+              elif host == "docs.ultralytics.com":
+                  urls_to_submit = filter_modified_urls(host, all_urls, os.environ['MODIFIED_FILES'].split())
+                  updated_urls = "\n".join(urls_to_submit)
+                  print(f'\nFound {len(urls_to_submit)} {host} URLs updated in last commit to submit:\n{updated_urls}\n')
+              else:
+                  urls_to_submit = []
+                  print(f'Skipping changed-file IndexNow submission for {host}; use submit_all_urls to submit all URLs.')
 
-          # Submit filtered URLs
-          if urls_to_submit:
-              submit_urls_to_indexnow(host, urls_to_submit)
+              # Submit filtered URLs
+              if urls_to_submit:
+                  submit_urls_to_indexnow(host, urls_to_submit)

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -76,9 +76,10 @@ jobs:
           }
           failed_sitemaps = []
           for host, paths in sitemap_paths.items():
+              site_url = "sc-domain:ultralytics.com" if host in {"academy.ultralytics.com", "handbook.ultralytics.com"} else f"https://{host}/"
               for path in paths:
                   sitemap = f'https://{host}{path}/sitemap.xml'
-                  if not submit_sitemap(f'https://{host}/', sitemap, credentials_json):
+                  if not submit_sitemap(site_url, sitemap, credentials_json):
                       failed_sitemaps.append(sitemap)
           if failed_sitemaps:
               raise SystemExit(f"Failed to submit {len(failed_sitemaps)} sitemap(s): {', '.join(failed_sitemaps)}")


### PR DESCRIPTION
## Summary
- add Academy, Handbook, and Platform root sitemap URLs to Google Search Console submission
- submit the new subdomain sitemaps through the verified `sc-domain:ultralytics.com` Search Console property
- keep IndexNow submissions scoped to docs URLs because Academy and Handbook do not currently serve the IndexNow key file
- fail the Google sitemap step if Search Console rejects any sitemap, so missing property access is visible

## Validation
- actionlint .github/workflows/sitemaps.yml
- python3 embedded workflow Python compile check
- git diff --check
- manual `Submit Sitemaps` workflow run `25250597720`: GSC submissions for Academy, Handbook, and Platform passed

## Remaining blocker
- IndexNow key files still return 404 on Academy and Handbook, so this PR remains draft until those hosts serve the key file or we decide to ship GSC first and add IndexNow later.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the sitemap submission workflow to support more Ultralytics sites, better detect failures, and make URL indexing updates more reliable 🚀

### 📊 Key Changes
- Added sitemap submission support for more Ultralytics domains, including `academy.ultralytics.com`, `handbook.ultralytics.com`, and `platform.ultralytics.com` 🌐
- Refactored sitemap handling into a domain-to-path mapping, making the workflow easier to extend and maintain 🛠️
- Updated Google sitemap submission logic to return success or failure for each sitemap and collect failed submissions ✅❌
- Added a hard failure if any sitemap submission fails, instead of silently continuing, improving visibility into indexing issues 🚨
- Used the `sc-domain:ultralytics.com` property for select subdomains when submitting to Google Search Console, aligning with domain-level verification 🔍
- Fixed environment variable writing by safely quoting `$GITHUB_ENV`, improving shell robustness 🧩
- Updated the IndexNow URL filtering helper to accept the host explicitly, making the logic cleaner and more reusable 🔄
- Kept IndexNow submissions focused on changed pages for `docs.ultralytics.com`, while leaving room to submit all URLs when needed 📄

### 🎯 Purpose & Impact
- Ensures more Ultralytics web properties are included in search engine discovery and indexing, not just the main docs and website 📈
- Makes CI failures easier to catch and act on, helping prevent missed sitemap submissions from going unnoticed 🛡️
- Improves maintainability of the workflow, so adding or updating domains/languages is simpler in the future ✨
- Reduces the chance of indexing delays by clearly reporting failed sitemap submissions and stopping on errors ⏱️
- Keeps IndexNow updates efficient by submitting only recently changed docs pages by default, which can reduce unnecessary indexing requests 🎯
- Overall, this PR strengthens search indexing automation and makes site update handling more dependable for users and maintainers alike 🤝