### PR TITLE
Increase Check Domains request timeout

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -86,7 +86,7 @@ jobs:
                           print(f"Retrying in {delay}s (attempt {attempt + 1}/{max_attempts})")
                           time.sleep(delay)
 
-                      response = requests.get(url, allow_redirects=True, timeout=10)
+                      response = requests.get(url, allow_redirects=True, timeout=20)
                       response.raise_for_status()
 
                       if any(dest in response.url for dest in valid_destinations) and response.status_code == 200:

--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -73,7 +73,7 @@ jobs:
           import requests
           import time
 
-          def check_domain_redirection(domain, prefix, max_attempts=5):
+          def check_domain_redirection(domain, prefix, max_attempts=6):
               """Check if the given domain redirects correctly, with exponential delays between retries."""
               valid_destinations = ["ultralytics.com", "yolo11.com"]
               url = f"https://{prefix}{domain}"


### PR DESCRIPTION
## Summary
- Increase the Check Domains per-request timeout from 10 seconds to 20 seconds.
- Add one more retry attempt, increasing each domain check from 5 attempts to 6.

## Validation
- actionlint .github/workflows/check_domains.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes the domain-checking GitHub Action more reliable by increasing retry attempts and allowing more time for redirect requests to complete.

### 📊 Key Changes
- Increased the maximum number of retry attempts in `.github/workflows/check_domains.yml` from `5` to `6` 🔁
- Extended the HTTP request timeout for domain redirect checks from `10` seconds to `20` seconds ⏱️
- Kept the existing redirect validation logic the same, still verifying that domains resolve successfully to approved destinations like `ultralytics.com` and `yolo11.com` ✅

### 🎯 Purpose & Impact
- Reduces false CI failures caused by slow network responses or temporary redirect delays 🌐
- Makes automated domain validation more stable and resilient in GitHub Actions 🛠️
- Helps maintain smoother documentation and site infrastructure checks without changing user-facing behavior 📚
- Improves confidence that valid redirects will pass even under less-than-ideal network conditions 🚀