### PR TITLE
Skip avatar-fallback initials in codespell check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -128,8 +128,11 @@ jobs:
           rm -rf "$SPELLCHECK_ROOT"
           mkdir "$SPELLCHECK_ROOT"
           cp -R "${{ matrix.website }}" "$SPELLCHECK_ROOT/"
+          # Also strip avatar-fallback elements: their text is auto-generated
+          # 2-letter contributor initials (e.g. "BU" for Burhan-Q) that codespell
+          # would otherwise flag as typos on every page.
           find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" \
-            -exec perl -0pi -e 's#<script\b[^>]*>.*?</script>##gis; s#<style\b[^>]*>.*?</style>##gis' {} +
+            -exec perl -0pi -e 's#<script\b[^>]*>.*?</script>##gis; s#<style\b[^>]*>.*?</style>##gis; s#<([a-z]+)\b[^>]*\bdata-slot="avatar-fallback"[^>]*>.*?</\1>##gis' {} +
           CODESPELL_OUTPUT=$(find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" -print0 | xargs -0 codespell \
             --builtin clear,rare,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \


### PR DESCRIPTION
## Summary

The daily `Website links and spellcheck` workflow has been failing because codespell flags contributor initials rendered inside avatar fallbacks (e.g. `BU` for `Burhan-Q`, `TE`) as misspellings on every docs page that has a Contributors section.

These initials are auto-generated presentational text, not prose. Extends the existing `<script>`/`<style>` strip pass to also remove `<*data-slot=\"avatar-fallback\">…</*>` elements before running codespell. Same pattern, same line.

This is a permanent fix — any future contributor with an unfortunate two-letter initial pair is handled automatically, so we don't keep growing `--ignore-words-list` every time a new contributor lands. (The existing list already has a number of suspicious 2–3 letter entries like `nd, ned, ane, nam, nin, fo, ore` that look like prior patches around this same issue and can probably be cleaned up in a follow-up once this run goes green.)

## Test plan
- [ ] Trigger the workflow via \`workflow_dispatch\` against \`docs.ultralytics.com\`
- [ ] Confirm the spellcheck step no longer reports \`BU\` / \`TE\` on every page
- [ ] Confirm no new false positives are introduced

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 Improves the docs link-check workflow by removing auto-generated avatar fallback text from HTML before spellchecking, reducing false-positive typo reports.

### 📊 Key Changes
- Updated `.github/workflows/links.yml` in the docs CI workflow.
- Expanded the HTML cleanup step used before running `codespell`.
- Continued stripping `<script>` and `<style>` content, and now also removes elements with `data-slot="avatar-fallback"`.
- Added a comment explaining why this new filter is needed: contributor avatar fallback initials like `"BU"` can be incorrectly flagged as spelling mistakes.

### 🎯 Purpose & Impact
- ✅ Reduces noisy spellcheck failures caused by auto-generated contributor initials rather than real documentation issues.
- 🔍 Helps CI focus on genuine spelling problems, making checks more reliable.
- ⚡ Saves maintainer time by avoiding repeated false alarms in PRs and site builds.
- 🛠️ Improves the overall docs maintenance workflow with a small but practical automation fix.