### PR TITLE
Accept HTTP 418 (teapot) in website link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,6 +5,7 @@
 #   - 401(Vimeo, 'unauthorized')
 #   - 403(OpenVINO, 'forbidden')
 #   - 415(ClearML, 'unsupported media type')
+#   - 418(IEEE, "I'm a teapot" anti-bot challenge)
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
 #   - 502(Zenodo, 'bad gateway')
@@ -195,7 +196,7 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,403,415,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,403,415,418,429,500..=599,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|.*\.run\.app|.*\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \


### PR DESCRIPTION
## Summary

The daily **Website links and spellcheck** run fails on a single line:

```
[418] https://www.ieee.org/ | Rejected status code: 418 I'm a teapot
```

`418 I'm a teapot` is an anti-bot challenge response (used by IEEE / Cloudflare-style protection), not a broken link — `ieee.org` returns `200` in a normal browser. The lychee `--accept` list already tolerates the other bot/rate-limit codes (`401, 403, 415, 429, 999`) but is missing `418`.

This adds `418` to the accept list so the checker stops flagging it as a hard failure.

## Why this is the only change needed

The job's failure check filters out `[TIMEOUT]` and `Error:` lines before testing for `4xx`:

```bash
grep -v "^\[TIMEOUT\]" summary.txt | grep -v "^\[ERROR\]" | grep -v "^Error:" | grep -qE "^\[4[0-9]{2}\]" && exit 1
```

So the ~40 HTTP/2 (`mckinsey.com`, `st.com`, etc.) and `[TIMEOUT]` entries (`gdpr.eu`, `epo.org`, …) in run #1446 are already non-failing by design — all verified live/`200` or bot-blocked. The lone `[418]` from `ieee.org` was the only thing tripping `exit 1`.

## Changes

- Add `418` to the lychee `--accept` range.
- Document it in the header comment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates the docs link-checking workflow to treat HTTP `418` responses from IEEE as acceptable, preventing false link-check failures caused by anti-bot protection.

### 📊 Key Changes
- Added a new note in `.github/workflows/links.yml` documenting that IEEE may return `418` due to an anti-bot challenge ☕
- Updated the link checker’s accepted status codes to include `418`
- Kept the rest of the workflow unchanged, so this is a small, targeted CI reliability improvement ✅

### 🎯 Purpose & Impact
- Reduces unnecessary CI failures when documentation includes valid IEEE links
- Makes automated link validation more robust against anti-bot responses from external sites 🛡️
- Helps maintainers avoid wasting time on false alarms and keeps docs PR checks smoother 🚀
- Improves contributor experience by making link-check results more accurate and predictable