### PR TITLE
Request compressed website downloads for link checks

### DIFF
--- a/.github/workflows/download_websites.yml
+++ b/.github/workflows/download_websites.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           mkdir website
           wget -P website \
+            --compression=auto \
             --recursive \
             --no-parent \
             --adjust-extension \

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -66,7 +66,7 @@ jobs:
 
           # Download initial sitemap and process
           echo "Downloading sitemap..."
-          SITEMAP=$(wget -qO- "https://${{ matrix.website }}/sitemap.xml") || { echo "Failed to download sitemap"; exit 1; }
+          SITEMAP=$(wget --compression=auto -qO- "https://${{ matrix.website }}/sitemap.xml") || { echo "Failed to download sitemap"; exit 1; }
           echo "$SITEMAP" | parse_sitemap > urls.txt
 
           # Process any subsitemaps if they exist
@@ -76,7 +76,7 @@ jobs:
             grep -v 'sitemap' urls.txt > urls.tmp || true
             while read -r submap; do
               echo "Processing submap: $submap"
-              SUBMAP_CONTENT=$(wget -qO- "$submap") || { echo "Failed to download submap: $submap"; continue; }
+              SUBMAP_CONTENT=$(wget --compression=auto -qO- "$submap") || { echo "Failed to download submap: $submap"; continue; }
               echo "$SUBMAP_CONTENT" | parse_sitemap >> urls.tmp
             done < subsitemaps.txt
             mv urls.tmp urls.txt || true
@@ -98,6 +98,7 @@ jobs:
 
           # Download all URLs
           wget \
+          --compression=auto \
           --adjust-extension \
           --reject "*.jpg*,*.jpeg*,*.png*,*.gif*,*.webp*,*.svg*,*.txt" \
           --input-file=urls.txt \


### PR DESCRIPTION
## Summary
- request gzip-compressed transfers when downloading sitemaps and website HTML for link checks
- keep Lychee scanning local decompressed HTML files unchanged

## Validation
- parsed updated workflow YAML files with PyYAML
- actionlint -ignore SC2004 -ignore SC2086 -ignore SC2129 .github/workflows/links.yml .github/workflows/download_websites.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR improves docs website download and link-check workflows by enabling automatic compression in `wget`, making CI downloads more efficient and reliable.

### 📊 Key Changes
- Added `--compression=auto` to the website download workflow in `.github/workflows/download_websites.yml`.
- Updated sitemap fetching in `.github/workflows/links.yml` to use compressed responses when downloading:
  - the main `sitemap.xml`
  - any nested subsitemaps
- Added `--compression=auto` to the bulk URL download step used during link validation.
- Kept the existing workflow logic unchanged, while optimizing how content is transferred over the network.

### 🎯 Purpose & Impact
- 🚀 Speeds up CI workflows by reducing the amount of data transferred when downloading websites and sitemaps.
- 💸 Can lower bandwidth usage, which is especially helpful when checking large documentation sites.
- 🛠️ Improves compatibility with servers that support compressed responses by explicitly allowing `wget` to use them.
- ✅ Helps link-checking and site mirroring jobs run more efficiently without changing their output or behavior for users.
- 📚 Benefits maintainers of `ultralytics/docs` through faster, leaner automation, while end users may see more dependable docs validation behind the scenes.