### PR TITLE
Use parallel curl downloads for website link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -67,7 +67,7 @@ jobs:
 
           # Download initial sitemap and process
           echo "Downloading sitemap..."
-          SITEMAP=$(wget --compression=auto -qO- "https://${{ matrix.website }}/sitemap.xml") || { echo "Failed to download sitemap"; exit 1; }
+          SITEMAP=$(curl --compressed -fsSL "https://${{ matrix.website }}/sitemap.xml") || { echo "Failed to download sitemap"; exit 1; }
           echo "$SITEMAP" | parse_sitemap > urls.txt
 
           # Process any subsitemaps if they exist
@@ -77,7 +77,7 @@ jobs:
             grep -v 'sitemap' urls.txt > urls.tmp || true
             while read -r submap; do
               echo "Processing submap: $submap"
-              SUBMAP_CONTENT=$(wget --compression=auto -qO- "$submap") || { echo "Failed to download submap: $submap"; continue; }
+              SUBMAP_CONTENT=$(curl --compressed -fsSL "$submap") || { echo "Failed to download submap: $submap"; continue; }
               echo "$SUBMAP_CONTENT" | parse_sitemap >> urls.tmp
             done < subsitemaps.txt
             mv urls.tmp urls.txt || true
@@ -90,26 +90,47 @@ jobs:
       - name: Download Website
         continue-on-error: true
         run: |
-          # Set higher wait seconds for discourse community to avoid 429 rate limit errors
-          if [ "${{ matrix.website }}" = "community.ultralytics.com" ]; then
-            WAIT=1
-          else
-            WAIT=0.001
-          fi
+          # Download all URLs as decompressed local HTML while using Brotli/gzip over the wire.
+          python - <<'PY'
+          from pathlib import Path
+          from urllib.parse import urlsplit
 
-          # Download all URLs
-          wget \
-          --compression=auto \
-          --adjust-extension \
-          --reject "*.jpg*,*.jpeg*,*.png*,*.gif*,*.webp*,*.svg*,*.txt" \
-          --input-file=urls.txt \
-          --no-clobber \
-          --no-parent \
-          --wait=$WAIT \
-          --random-wait \
-          --tries=3 \
-          --no-verbose \
-          --force-directories
+          reject_suffixes = (".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".txt")
+
+          def quote(value: str) -> str:
+              return value.replace("\\", "\\\\").replace('"', '\\"')
+
+          count = 0
+          with open("urls.txt", encoding="utf-8") as urls, open("curl-downloads.txt", "w", encoding="utf-8") as config:
+              for url in (line.strip() for line in urls):
+                  if not url:
+                      continue
+                  parsed = urlsplit(url)
+                  path = f"{parsed.netloc}{parsed.path}"
+                  if path.endswith("/"):
+                      output = f"{path}index.html"
+                  elif "." in Path(path).name:
+                      output = path
+                  else:
+                      output = f"{path}.html"
+                  if output.lower().endswith(reject_suffixes) or Path(output).exists():
+                      continue
+                  config.write(f'url = "{quote(url)}"\noutput = "{quote(output)}"\n')
+                  count += 1
+          print(f"Prepared {count} page downloads")
+          PY
+
+          curl --compressed \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 3 \
+            --retry-all-errors \
+            --create-dirs \
+            --parallel \
+            --parallel-max 16 \
+            --config curl-downloads.txt || true
 
       - name: Check image sizes
         if: github.event_name != 'workflow_dispatch' || inputs.check_images


### PR DESCRIPTION
## Summary
- replace serial Wget page mirroring in the website link checker with one generated curl config and a single parallel curl invocation
- use curl --compressed so GitHub runner curl can negotiate Brotli when supported and still save decompressed HTML locally
- keep concurrency bounded with --parallel-max 16 for the 600-1100 page sites

## Validation
- parsed updated workflow YAML with PyYAML
- actionlint -ignore SC2004 -ignore SC2086 -ignore SC2129 .github/workflows/links.yml .github/workflows/download_websites.yml
- git diff --check
- local curl config smoke test confirmed url/output pairs create expected files

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Replaced `wget` with compressed, parallel `curl` downloads to make the documentation link-check workflow more reliable and efficient.

### 📊 Key Changes
- Switched sitemap and subsitemap retrieval from `wget` to `curl` with compression, failure handling, and redirects.
- Replaced sequential `wget` page downloads with a Python-generated `curl` configuration.
- Added automatic local output paths for downloaded pages, including `.html` extensions and `index.html` for directory URLs.
- Added filtering for image and text assets, plus skipping files that already exist.
- Enabled up to 16 parallel downloads with retries and automatic directory creation.
- Preserved non-blocking workflow behavior by allowing bulk download errors to continue.

### 🎯 Purpose & Impact
- ⚡ Speeds up website downloads through parallel processing and compressed transfers.
- 🛡️ Improves resilience against transient network failures with retries and clearer error reporting.
- 📁 Produces predictable local HTML files for more dependable link checking.
- 🔄 Avoids repeatedly downloading existing pages, reducing workflow time and bandwidth usage.
- ✅ Helps documentation validation run more efficiently across supported websites.