### PR TITLE
Improve docs, comments, and correctness

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralics website domain checks
+# Ultralytics website domain checks
 
 name: Check Domains
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Welcome to Ultralytics Docs, your comprehensive resource for understanding and u
 [![Downloads](https://static.pepy.tech/badge/ultralytics)](https://clickpy.clickhouse.com/dashboard/ultralytics)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics/)
 
-To install the `ultralytics` package in developer mode, which allows you to modify the source code directly, ensure you have [Git](https://git-scm.com/downloads/) and [Python](https://www.python.org/downloads/) 3.9 or later installed on your system. Then, follow these steps:
+To install the `ultralytics` package in developer mode, which allows you to modify the source code directly, ensure you have [Git](https://git-scm.com/downloads/) and [Python](https://www.python.org/downloads/) 3.8 or later installed on your system. Then, follow these steps:
 
 1.  Clone the `ultralytics` repository to your local machine using Git:
 
@@ -104,7 +104,7 @@ If your documentation supports multiple languages, follow these steps to build a
 To deploy your MkDocs documentation site, choose a hosting provider and configure your deployment method. Common options include [GitHub Pages](https://pages.github.com/), GitLab Pages, or other static site hosting services like [Netlify](https://www.netlify.com/) or [Vercel](https://vercel.com/).
 
 - Configure deployment settings within your `mkdocs.yml` file.
-- Use the `mkdocs deploy` command specific to your chosen provider to build and deploy your site.
+- Use the deployment method specific to your chosen provider to build and deploy your site.
 
 * **GitHub Pages Deployment Example:**
   If deploying to GitHub Pages, you can use the built-in command:

--- a/docs/en/compare/damo-yolo-vs-yolo11.md
+++ b/docs/en/compare/damo-yolo-vs-yolo11.md
@@ -10,7 +10,7 @@ When choosing a real-time object detection architecture for your next computer v
 
 **DAMO-YOLO Details:**  
 Authors: Xianzhe Xu, Yiqi Jiang, Weihua Chen, Yilun Huang, Yuan Zhang, and Xiuyu Sun  
-Organization: [Alibaba Group](https://www.alibabagroup.com/)
+Organization: [Alibaba Group](https://www.alibabagroup.com/)  
 Date: 2022-11-23  
 Arxiv: [2211.15444v2](https://arxiv.org/abs/2211.15444v2)  
 GitHub: [tinyvision/DAMO-YOLO](https://github.com/tinyvision/DAMO-YOLO)  

--- a/docs/en/compare/efficientdet-vs-rtdetr.md
+++ b/docs/en/compare/efficientdet-vs-rtdetr.md
@@ -61,7 +61,7 @@ RTDETRv2 represents the evolution of transformer-based architectures, shifting t
 
 RTDETRv2 excels in high-density environments where overlapping objects confuse traditional CNNs. It is highly accurate on complex benchmark [datasets like COCO](https://docs.ultralytics.com/datasets/detect/coco).
 
-Despite its accuracy, transformer models naturally demand substantial memory. The training efficiency is notably lower; it requires significantly more epochs and higher [CUDA](https://developer.nvidia.com/cuda/toolkit) memory footprints to converge compared to CNNs. This makes RTDETRv2 less ideal for developers operating with constrained cloud budgets or those needing rapid rapid prototyping.
+Despite its accuracy, transformer models naturally demand substantial memory. The training efficiency is notably lower; it requires significantly more epochs and higher [CUDA](https://developer.nvidia.com/cuda/toolkit) memory footprints to converge compared to CNNs. This makes RTDETRv2 less ideal for developers operating with constrained cloud budgets or those needing rapid prototyping.
 
 [Learn more about RTDETRv2](https://github.com/lyuwenyu/RT-DETR/tree/main/rtdetrv2_pytorch){ .md-button }
 

--- a/docs/en/compare/efficientdet-vs-yolo11.md
+++ b/docs/en/compare/efficientdet-vs-yolo11.md
@@ -50,7 +50,7 @@ The architectural differences between these two models highlight the divergence 
 
 EfficientDet leverages the EfficientNet backbone and introduces BiFPN, which allows for top-down and bottom-up multi-scale feature fusion. It uses a compound scaling method that uniformly scales the resolution, depth, and width for all backbone, feature network, and box/class prediction networks simultaneously. While highly effective for maximizing [mean Average Precision (mAP)](https://www.ultralytics.com/glossary/mean-average-precision-map), the complex routing in BiFPN can sometimes bottleneck memory bandwidth during inference.
 
-YOLO11, on the other hand, utilizes an optimized C2f module and an advanced anchor-free detection head. This streamlined approach minimizes overhead during feature extraction. Ultralytics engineered YOLO11 to maximize GPU hardware utilization, resulting in significantly lower memory requirements during both training and inference compared to older architectures or heavy [transformer](https://www.ultralytics.com/glossary/transformer) models.
+YOLO11, on the other hand, utilizes an optimized C3k2 module and an advanced anchor-free detection head. This streamlined approach minimizes overhead during feature extraction. Ultralytics engineered YOLO11 to maximize GPU hardware utilization, resulting in significantly lower memory requirements during both training and inference compared to older architectures or heavy [transformer](https://www.ultralytics.com/glossary/transformer) models.
 
 !!! tip "Multi-Task Versatility"
 

--- a/docs/en/compare/index.md
+++ b/docs/en/compare/index.md
@@ -245,7 +245,7 @@ RT-DETR (Real-Time Detection Transformer) leverages vision transformers to achie
 - [RT-DETR vs YOLOX](rtdetr-vs-yolox.md)
 - [RT-DETR vs EfficientDet](rtdetr-vs-efficientdet.md)
 
-### [PP-YOLOE+](../models/yoloe.md) vs
+### PP-YOLOE+ vs
 
 PP-YOLOE+, developed by Baidu, uses Task Alignment Learning (TAL) and a decoupled head to balance efficiency and accuracy.
 

--- a/docs/en/compare/index.md
+++ b/docs/en/compare/index.md
@@ -94,7 +94,7 @@ Explore our in-depth technical comparisons to understand specific architectural 
 
 ### [YOLO26](../models/yolo26.md) vs
 
-YOLO26 is the latest Ultralytics model featuring NMS-free end-to-end detection, the MuSGD optimizer, and up to 43% faster CPU inference. It's optimized for edge deployment while achieving state-of-the-art accuracy.
+[YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) is the latest Ultralytics model featuring NMS-free end-to-end detection, the MuSGD optimizer, and up to 43% faster CPU inference. It's optimized for edge deployment while achieving state-of-the-art accuracy.
 
 - [YOLO26 vs YOLO11](yolo26-vs-yolo11.md)
 - [YOLO26 vs YOLOv10](yolo26-vs-yolov10.md)
@@ -111,7 +111,7 @@ YOLO26 is the latest Ultralytics model featuring NMS-free end-to-end detection, 
 
 ### [YOLO11](../models/yolo11.md) vs
 
-YOLO11 builds upon the success of its predecessors with cutting-edge research. It features an improved backbone and neck architecture for better feature extraction and optimized efficiency.
+[YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) builds upon the success of its predecessors with cutting-edge research. It features an improved backbone and neck architecture for better feature extraction and optimized efficiency.
 
 - [YOLO11 vs YOLO26](yolo11-vs-yolo26.md)
 - [YOLO11 vs YOLOv10](yolo11-vs-yolov10.md)
@@ -162,7 +162,7 @@ YOLOv9 introduces Programmable Gradient Information (PGI) and the Generalized Ef
 
 ### [YOLOv8](../models/yolov8.md) vs
 
-Ultralytics YOLOv8 remains a highly popular choice, featuring advanced backbone and neck architectures and an anchor-free split head for optimal accuracy-speed tradeoffs.
+[Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) remains a highly popular choice, featuring advanced backbone and neck architectures and an anchor-free split head for optimal accuracy-speed tradeoffs.
 
 - [YOLOv8 vs YOLO26](yolov8-vs-yolo26.md)
 - [YOLOv8 vs YOLO11](yolov8-vs-yolo11.md)
@@ -213,7 +213,7 @@ Meituan's YOLOv6 is designed for industrial applications, featuring Bi-direction
 
 ### [YOLOv5](../models/yolov5.md) vs
 
-Ultralytics YOLOv5 is celebrated for its ease of use, stability, and speed. It remains a robust choice for projects requiring broad device compatibility.
+[Ultralytics YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5) is celebrated for its ease of use, stability, and speed. It remains a robust choice for projects requiring broad device compatibility.
 
 - [YOLOv5 vs YOLO26](yolov5-vs-yolo26.md)
 - [YOLOv5 vs YOLO11](yolov5-vs-yolo11.md)

--- a/docs/en/compare/pp-yoloe-vs-yolo11.md
+++ b/docs/en/compare/pp-yoloe-vs-yolo11.md
@@ -58,7 +58,7 @@ PP-YOLOE+ relies heavily on the [PaddlePaddle framework](https://github.com/Padd
 
 ### YOLO11 Architecture
 
-Ultralytics YOLO11 is built natively on [PyTorch](https://pytorch.org/), the industry standard for modern deep learning. Its architecture focuses heavily on a **Performance Balance**, achieving a favorable trade-off between speed and accuracy suitable for diverse real-world deployment scenarios. YOLO11 features an optimized C2f module for better gradient flow and a decoupled head that efficiently handles classification and regression tasks separately. Furthermore, YOLO11 is engineered for lower memory requirements, boasting significantly lower memory usage during training and inference compared to complex transformer models like [RT-DETR](https://docs.ultralytics.com/models/rtdetr).
+Ultralytics YOLO11 is built natively on [PyTorch](https://pytorch.org/), the industry standard for modern deep learning. Its architecture focuses heavily on a **Performance Balance**, achieving a favorable trade-off between speed and accuracy suitable for diverse real-world deployment scenarios. YOLO11 features an optimized C3k2 module for better gradient flow and a decoupled head that efficiently handles classification and regression tasks separately. Furthermore, YOLO11 is engineered for lower memory requirements, boasting significantly lower memory usage during training and inference compared to complex transformer models like [RT-DETR](https://docs.ultralytics.com/models/rtdetr).
 
 ### Performance Metrics Table
 

--- a/docs/en/compare/rtdetr-vs-efficientdet.md
+++ b/docs/en/compare/rtdetr-vs-efficientdet.md
@@ -49,7 +49,7 @@ Links: [Arxiv](https://arxiv.org/abs/1911.09070), [GitHub](https://github.com/go
 
 The innovation behind EfficientDet lies in two key areas: the Bi-directional Feature Pyramid Network (BiFPN) and a compound scaling method. BiFPN allows for simple and fast multi-scale [feature extraction](https://www.ultralytics.com/glossary/feature-extraction) by introducing learnable weights to learn the importance of different input features, while repeatedly applying top-down and bottom-up multi-scale feature fusion. The compound scaling method uniformly scales the resolution, depth, and width of the network simultaneously.
 
-EfficientDet models range from the ultra-lightweight D0 to the massive D7. This makes them highly versatile for [edge AI](https://www.ultralytics.com/glossary/edge-ai) deployments where developers must balance tight computational budgets with accuracy requirements, such as early mobile [augmented reality](https://www.ultralytics.com/glossary/merged-reality) applications.
+EfficientDet models range from the ultra-lightweight D0 to the massive D7. This makes them highly versatile for [edge AI](https://www.ultralytics.com/glossary/edge-ai) deployments where developers must balance tight computational budgets with accuracy requirements, such as early mobile [augmented reality](https://en.wikipedia.org/wiki/Augmented_reality) applications.
 
 ### Limitations
 

--- a/docs/en/compare/yolo11-vs-yolov5.md
+++ b/docs/en/compare/yolo11-vs-yolov5.md
@@ -25,7 +25,7 @@ Both models reflect Ultralytics' commitment to open-source collaboration, robust
 - Organization: [Ultralytics](https://www.ultralytics.com/)
 - Date: 2024-09-27
 - GitHub: [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics)
-- Docs: [YOLO11 Documentation](https://platform.ultralytics.com/ultralytics/yolo11)
+- Docs: [YOLO11 Documentation](https://docs.ultralytics.com/models/yolo11)
 
 [Learn more about YOLO11](https://platform.ultralytics.com/ultralytics/yolo11){ .md-button }
 
@@ -35,7 +35,7 @@ Both models reflect Ultralytics' commitment to open-source collaboration, robust
 - Organization: [Ultralytics](https://www.ultralytics.com/)
 - Date: 2020-06-26
 - GitHub: [ultralytics/yolov5](https://github.com/ultralytics/yolov5)
-- Docs: [YOLOv5 Documentation](https://platform.ultralytics.com/ultralytics/yolov5)
+- Docs: [YOLOv5 Documentation](https://docs.ultralytics.com/models/yolov5)
 
 [Learn more about YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5){ .md-button }
 

--- a/docs/en/compare/yolo26-vs-yolov7.md
+++ b/docs/en/compare/yolo26-vs-yolov7.md
@@ -76,7 +76,7 @@ The table below provides a direct comparison of the models trained on the standa
 | YOLOv7l | 640                         | 51.4                       | -                                    | 6.84                                      | 36.9                     | 104.7                   |
 | YOLOv7x | 640                         | 53.1                       | -                                    | 11.57                                     | 71.3                     | 189.9                   |
 
-_Note: YOLO26x outperforms YOLOv7x in mAP by an impressive margin (57.5 vs 53.1) while requiring approximately 22% fewer parameters and fewer FLOPs._
+_Note: YOLO26x outperforms YOLOv7x in mAP by an impressive margin (57.5 vs 53.1) while requiring approximately 22% fewer parameters._
 
 ## The Ultralytics Ecosystem Advantage
 

--- a/docs/en/compare/yolov5-vs-efficientdet.md
+++ b/docs/en/compare/yolov5-vs-efficientdet.md
@@ -23,7 +23,7 @@ Released in the summer of 2020, YOLOv5 marked a pivotal shift in the YOLO lineag
 - **Organization:** [Ultralytics](https://www.ultralytics.com/)
 - **Date:** 2020-06-26
 - **GitHub:** <https://github.com/ultralytics/yolov5>
-- **Docs:** <https://platform.ultralytics.com/ultralytics/yolov5>
+- **Docs:** <https://docs.ultralytics.com/models/yolov5>
 
 ### Architectural Innovations
 

--- a/docs/en/compare/yolov5-vs-yolov9.md
+++ b/docs/en/compare/yolov5-vs-yolov9.md
@@ -27,7 +27,7 @@ Developed by Glenn Jocher and released by [Ultralytics](https://www.ultralytics.
 - **Organization:** [Ultralytics](https://www.ultralytics.com/)
 - **Date:** 2020-06-26
 - **GitHub:** [YOLOv5 Repository](https://github.com/ultralytics/yolov5)
-- **Docs:** [YOLOv5 Platform Overview](https://platform.ultralytics.com/ultralytics/yolov5)
+- **Docs:** [YOLOv5 Documentation](https://docs.ultralytics.com/models/yolov5)
 
 YOLOv5 is renowned for its **Ease of Use** and stable performance across diverse hardware environments. It supports not just detection, but also [image classification](https://docs.ultralytics.com/tasks/classify) and [instance segmentation](https://docs.ultralytics.com/tasks/segment).
 

--- a/docs/en/compare/yolov6-vs-yolo26.md
+++ b/docs/en/compare/yolov6-vs-yolo26.md
@@ -40,13 +40,13 @@ Released in January 2026, **Ultralytics YOLO26** represents a paradigm shift. It
 - **Organization:** [Ultralytics](https://www.ultralytics.com/)
 - **Date:** 2026-01-14
 - **GitHub:** [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics)
-- **Docs:** [YOLO26 Documentation](https://platform.ultralytics.com/ultralytics/yolo26)
+- **Docs:** [YOLO26 Documentation](https://docs.ultralytics.com/models/yolo26)
 
 ### Key Architectural Breakthroughs
 
 YOLO26 introduces several pioneering advancements that set it apart from previous generations:
 
-- **End-to-End NMS-Free Design:** Building on concepts first pioneered in [YOLOv10](https://docs.ultralytics.com/models/yolov10), YOLO26 is natively end-to-end. It completely eliminates [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, resulting in a dramatic reduction in latency variability and drastically simpler deployment logic.
+- **End-to-End NMS-Free Design:** Building on concepts first pioneered in [YOLOv10](https://docs.ultralytics.com/models/yolov10), YOLO26 is natively end-to-end. It completely eliminates [Non-Maximum Suppression (NMS)](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) post-processing, resulting in a dramatic reduction in latency variability and drastically simpler deployment logic.
 - **Up to 43% Faster CPU Inference:** Optimized explicitly for edge computing, YOLO26 excels on devices without GPUs, making it ideal for mobile phones, IoT sensors, and robotics.
 - **DFL Removal:** The Distribution Focal Loss has been removed, simplifying the model export process and enhancing compatibility with low-power edge devices.
 - **MuSGD Optimizer:** Inspired by LLM training innovations like Moonshot AI's Kimi K2, the new MuSGD optimizer (a hybrid of [Stochastic Gradient Descent](https://en.wikipedia.org/wiki/Stochastic_gradient_descent) and Muon) brings large-scale stability to vision tasks, ensuring faster convergence.

--- a/docs/en/compare/yolov7-vs-rtdetr.md
+++ b/docs/en/compare/yolov7-vs-rtdetr.md
@@ -28,7 +28,7 @@ GitHub: [WongKinYiu/yolov7](https://github.com/WongKinYiu/yolov7)
 
 ### Architecture and Strengths
 
-YOLOv7 thrives on its Extended Efficient Layer Aggregation Network (E-ELAN) architecture. This structural design enables the model to learn more diverse features without destroying the original gradient path. Furthermore, it incorporates planned re-parameterized convolutions, which optimize inference speed without degrading accuracy. Its decoupled head structure allows it to achieve impressive trade-offs between speed and accuracy, making it highly suitable for [real-time object detection](https://docs.ultralytics.com/tasks/detect) tasks on server-grade GPUs.
+YOLOv7 thrives on its Extended Efficient Layer Aggregation Network (E-ELAN) architecture. This structural design enables the model to learn more diverse features without destroying the original gradient path. Furthermore, it incorporates planned re-parameterized convolutions, which optimize inference speed without degrading accuracy. Its trainable bag-of-freebies approach allows it to achieve impressive trade-offs between speed and accuracy, making it highly suitable for [real-time object detection](https://docs.ultralytics.com/tasks/detect) tasks on server-grade GPUs.
 
 YOLOv7 is also highly versatile. Beyond standard bounding box detection, the repository offers branches for [pose estimation](https://docs.ultralytics.com/tasks/pose) and [instance segmentation](https://docs.ultralytics.com/tasks/segment), demonstrating its adaptability.
 

--- a/docs/en/compare/yolov7-vs-yolo26.md
+++ b/docs/en/compare/yolov7-vs-yolo26.md
@@ -26,7 +26,7 @@ Introduced in mid-2022, YOLOv7 pushed the boundaries of what was possible on GPU
 - **GitHub:** [WongKinYiu/yolov7](https://github.com/WongKinYiu/yolov7)
 - **Docs:** [Ultralytics YOLOv7 Documentation](https://docs.ultralytics.com/models/yolov7)
 
-YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive state-of-the-art benchmark on COCO at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://en.wikipedia.org/wiki/NMS) post-processing, which can introduce latency bottlenecks during deployment.
+YOLOv7 introduced the concept of trainable "bag-of-freebies," which heavily utilized re-parameterization techniques and extended efficient layer aggregation networks (E-ELAN). This allowed the model to learn more diverse features and continuously improve the learning capability of the network without destroying the original gradient path. While it achieved an impressive state-of-the-art benchmark on COCO at the time, its architecture remains heavily reliant on anchor-based outputs and requires complex [Non-Maximum Suppression (NMS)](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) post-processing, which can introduce latency bottlenecks during deployment.
 
 [Learn more about YOLOv7](https://docs.ultralytics.com/models/yolov7){ .md-button }
 

--- a/docs/en/compare/yolov8-vs-yolo11.md
+++ b/docs/en/compare/yolov8-vs-yolo11.md
@@ -55,7 +55,7 @@ YOLOv8 introduced a streamlined CNN backbone that moved away from traditional an
 
 ### Memory Requirements and Training Efficiency
 
-One of the most notable advantages of both YOLOv8 and YOLO11 is their **low memory requirements** during training. Unlike heavy vision transformers that can easily exhaust VRAM on consumer hardware, these models are optimized for accessible [PyTorch](https://pytorch.org/) training on standard GPUs. YOLO11 achieves a substantial reduction in total parameters—up to 22% fewer parameters in the large (L) variant compared to YOLOv8—while simultaneously increasing its Mean Average Precision (mAP). This means faster epochs and a lower carbon footprint for model training.
+One of the most notable advantages of both YOLOv8 and YOLO11 is their **low memory requirements** during training. Unlike heavy vision transformers that can easily exhaust VRAM on consumer hardware, these models are optimized for accessible [PyTorch](https://pytorch.org/) training on standard GPUs. YOLO11 achieves a substantial reduction in total parameters—up to 42% fewer parameters in the large (L) variant compared to YOLOv8—while simultaneously increasing its Mean Average Precision (mAP). This means faster epochs and a lower carbon footprint for model training.
 
 ## Performance Metrics
 

--- a/docs/en/compare/yolov9-vs-rtdetr.md
+++ b/docs/en/compare/yolov9-vs-rtdetr.md
@@ -40,7 +40,7 @@ Understanding the origins and design intent of these models provides crucial con
 ### RTDETRv2
 
 **Authors:** Wenyu Lv, Yian Zhao, Qinyao Chang, Kui Huang, Guanzhong Wang, and Yi Liu  
-**Organization:** [Baidu](https://www.baidu.com/)
+**Organization:** [Baidu](https://www.baidu.com/)  
 **Date:** 2024-07-24  
 **Arxiv:** [https://arxiv.org/abs/2407.17140](https://arxiv.org/abs/2407.17140)  
 **GitHub:** [lyuwenyu/RT-DETR](https://github.com/lyuwenyu/RT-DETR/tree/main/rtdetrv2_pytorch)

--- a/docs/en/compare/yolov9-vs-yolov10.md
+++ b/docs/en/compare/yolov9-vs-yolov10.md
@@ -24,9 +24,9 @@ Understanding the lineage and theoretical foundations of these models is crucial
 Introduced on February 21, 2024, YOLOv9 tackles the theoretical issue of information loss as data passes through deep neural networks.
 
 - **Authors:** Chien-Yao Wang and Hong-Yuan Mark Liao
-- **Organization:**[Institute of Information Science, Academia Sinica, Taiwan](https://www.iis.sinica.edu.tw/en/index.html)
-- **Reference:**[YOLOv9 arXiv Paper](https://arxiv.org/abs/2402.13616)
-- **Repository:**[YOLOv9 GitHub](https://github.com/WongKinYiu/yolov9)
+- **Organization:** [Institute of Information Science, Academia Sinica, Taiwan](https://www.iis.sinica.edu.tw/en/index.html)
+- **Reference:** [YOLOv9 arXiv Paper](https://arxiv.org/abs/2402.13616)
+- **Repository:** [YOLOv9 GitHub](https://github.com/WongKinYiu/yolov9)
 
 YOLOv9 introduces the **Generalized Efficient Layer Aggregation Network (GELAN)**, which maximizes parameter utilization by combining the strengths of CSPNet and ELAN. Furthermore, it employs **Programmable Gradient Information (PGI)**, an auxiliary supervision mechanism ensuring deep layers retain critical spatial information. This makes YOLOv9 exceptionally strong for tasks demanding high feature fidelity, such as [medical image analysis](https://www.ultralytics.com/glossary/medical-image-analysis) or distant surveillance.
 
@@ -37,9 +37,9 @@ YOLOv9 introduces the **Generalized Efficient Layer Aggregation Network (GELAN)*
 Released shortly after on May 23, 2024, YOLOv10 reimagines the deployment pipeline by eliminating one of the most notorious latency bottlenecks in object detection: Non-Maximum Suppression (NMS).
 
 - **Authors:** Ao Wang, Hui Chen, Lihao Liu, et al.
-- **Organization:**[Tsinghua University](https://www.tsinghua.edu.cn/en/)
-- **Reference:**[YOLOv10 arXiv Paper](https://arxiv.org/abs/2405.14458)
-- **Repository:**[YOLOv10 GitHub](https://github.com/THU-MIG/yolov10)
+- **Organization:** [Tsinghua University](https://www.tsinghua.edu.cn/en/)
+- **Reference:** [YOLOv10 arXiv Paper](https://arxiv.org/abs/2405.14458)
+- **Repository:** [YOLOv10 GitHub](https://github.com/THU-MIG/yolov10)
 
 YOLOv10 utilizes **consistent dual assignments** during training, allowing for a natively **NMS-free design**. This removes post-processing overhead during inference, drastically reducing latency. Combined with a holistic efficiency-accuracy driven model design, YOLOv10 achieves an outstanding balance, lowering computational overhead (FLOPs) while maintaining competitive precision, making it highly attractive for [edge computing](https://www.ultralytics.com/glossary/edge-computing) applications.
 

--- a/docs/en/compare/yolox-vs-yolo26.md
+++ b/docs/en/compare/yolox-vs-yolo26.md
@@ -117,7 +117,7 @@ Selecting between YOLOX and YOLO26 ultimately depends on your deployment constra
 
 ### Where YOLOX Excels
 
-YOLOX remains a viable candidate for specific academic benchmarks and legacy systems heavily deeply integrated with the MegEngine framework. Its historical significance makes it a popular baseline for researching [anchor-free detectors](https://www.ultralytics.com/glossary/anchor-free-detectors) and custom assignment strategies.
+YOLOX remains a viable candidate for specific academic benchmarks and legacy systems deeply integrated with the MegEngine framework. Its historical significance makes it a popular baseline for researching [anchor-free detectors](https://www.ultralytics.com/glossary/anchor-free-detectors) and custom assignment strategies.
 
 ### Where YOLO26 Excels
 


### PR DESCRIPTION
Full-repo correctness audit of all 176 tracked files (157 compare pages, workflows, README, configs, utility script). Every file was inspected line by line; performance tables, model metadata, bold markers, and relative links were additionally cross-checked mechanically across the whole corpus and against the `ultralytics` repo sources (`docs/en/models/*.md`, `docs/macros/yolo-det-perf.md`, `docs/overrides/javascript/benchmark.js`, `cfg/models/*/*.yaml`, `pyproject.toml`). Only high-confidence corrections are included; the diff is intentionally minimal (27 changed lines across 19 files).

## Correction categories

**Factual errors (4)**

- `pp-yoloe-vs-yolo11.md`, `efficientdet-vs-yolo11.md`: YOLO11 uses `C3k2` blocks, not `C2f` (per `ultralytics/cfg/models/11/yolo11.yaml`; `C2f` is the YOLOv8 block)
- `yolov7-vs-rtdetr.md`: YOLOv7 has no decoupled head (coupled IDetect/IAuxDetect); replaced with its actual signature feature, the trainable bag-of-freebies approach
- `yolov8-vs-yolo11.md`: "22% fewer parameters in the large (L) variant" → 42% (table: 43.7M → 25.3M = 42.1%; 22% matches the M variant, not L)
- `yolo26-vs-yolov7.md`: removed false "and fewer FLOPs" (table: YOLO26x 193.9B > YOLOv7x 189.9B); the 22% parameter claim is correct and retained

**Wrong link targets (9 lines)**

- 5 compare-page `Docs:` metadata fields pointed at `platform.ultralytics.com` project pages while labeled "Documentation"; now point at the actual model docs pages, matching the 70+ sibling pages ("Learn more" Platform buttons untouched)
- 2 pages linked "Non-Maximum Suppression (NMS)" to the Wikipedia *NMS* acronym disambiguation page; now use the NMS glossary entry like the rest of the corpus
- `rtdetr-vs-efficientdet.md`: "augmented reality" anchor linked the merged-reality glossary entry (a different concept; no AR glossary page exists); now links the Wikipedia AR article
- `compare/index.md`: the PP-YOLOE+ section heading linked `../models/yoloe.md` — YOLOE is an unrelated model; heading is now unlinked like the DAMO-YOLO/YOLOX/EfficientDet siblings

**Markdown/grammar defects (12 lines)**

- `yolov9-vs-yolov10.md`: 6 metadata bullets missing the space after the bold label (`**Organization:**[…`)
- `damo-yolo-vs-yolo11.md`, `yolov9-vs-rtdetr.md`: one metadata line per file missing the trailing two-space hard break its sibling lines use, collapsing two fields onto one rendered line
- `efficientdet-vs-rtdetr.md`: "rapid rapid prototyping"; `yolox-vs-yolo26.md`: "heavily deeply integrated"

**Infra/README (3 lines)**

- `check_domains.yml`: "Ultralics" → "Ultralytics" in the workflow description comment
- `README.md`: Python requirement aligned with `ultralytics` `requires-python = ">=3.8"` (was 3.9), and removed the reference to a nonexistent `mkdocs deploy` command

## Validation

- `git diff --check`: clean except the two intentional Markdown hard-break additions (trailing two-space lines matching the byte-exact sibling-line convention; prettier preserves them)
- `npx prettier --check` on all 19 changed files: pass
- `codespell` on changed files: pass
- `check_domains.yml` parses (`yaml.safe_load`)
- Every added/changed URL verified live (HTTP 200): `docs.ultralytics.com/models/{yolo11,yolov5,yolo26}`, the NMS glossary entry, the Wikipedia AR article
- Mechanical re-runs post-edit: all compare-page tables still consistent per-variant across the corpus and vs ground truth; zero residual instances of any fixed defect class (`Docs:`→platform, `wiki/NMS`, YOLO11+C2f, `:**[`)

## Verification sources

Local `ultralytics` repo (model YAMLs, model docs, perf macros, benchmark.js, pyproject.toml), live docs.ultralytics.com / platform.ultralytics.com / ultralytics.com glossary pages, arXiv records, and this repo's own benchmark tables and sibling-page conventions.

## Review process

The consolidated candidate list (27 accepted, 4 rejected, 4 deferred) was independently reviewed before implementation by three separate review passes, then the final diff was re-reviewed by three fresh passes. Reviewer feedback incorporated: the YOLOv7 fix wording was tightened to "trainable bag-of-freebies", the AR link fix was redirected to the Wikipedia AR article to preserve the sentence's meaning, and the NMS-link rationale was corrected (disambiguation page, not 404). Final reviews: no blockers, all 19 files clean.

## Intentionally not changed (for maintainer awareness)

- `yolov5-vs-yolo11.md:76` "YOLO11 introduced … blocks like C2f and later C3k2" — sloppy lineage phrasing but defensible as describing the post-YOLOv5 evolution; left as is
- SEO meta descriptions of `yolo26-vs-yolov7.md` / `yolo26-vs-yolov9.md` read "Compare YOLO26 vs YOLOvX NMS-free YOLO26, …" — garbled but keyword-stuffed SEO text; left as is
- EfficientDet organization naming varies across pages (Google / Google Brain / Google Research) — all defensible
- "1.3% higher mAP" (`yolo11-vs-yolov8.md:70`) is 1.3 mAP points — common usage, left as is

## CI / log inspection

All 5 PR checks green: **Ultralytics Actions** (format/spell/labels), **Check Broken Repo links** (lychee: 4,926 links, 583 unique, 0 errors), **CodeQL** + **Analyze (actions)** + **Analyze (python)**. Job logs were inspected directly, not just statuses: no warnings, deprecations, or suspicious skips attributable to this change; the only `git diff --check` notes are the two intentional Markdown hard-break lines. The Actions bot pushed no auto-format commit (branch head unchanged), confirming the diff is formatter-stable. The automated reviewer left two advisory comments (README Python floor; Docs-vs-Platform link split) — both answered inline with source-of-truth citations: the 3.8 floor matches `ultralytics` `requires-python=">=3.8"` and the identical sentence in the main repo's docs README, and the "Learn more" Platform buttons are intentional cross-links left out of scope.

## Platform backlinks (second pass)

A coverage scan showed every compare page already carries Platform backlinks for the major models ("Learn more" buttons on all 96 subject pages plus in-prose links on 156/157 pages) — except the compare hub `index.md` itself, which had none. The second commit links the first prose mention of YOLO26, YOLO11, YOLOv8, and YOLOv5 in their hub sections to their Platform project pages (`platform.ultralytics.com/ultralytics/<model>`), using the model-name anchor convention already established across the corpus. All four URLs verified live; prettier/codespell clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR mainly improves documentation quality across the Ultralytics docs by fixing wording, correcting technical details, and updating many model links for better accuracy and navigation 📝🔗

### 📊 Key Changes
- Updated multiple docs pages to fix typos, spacing, grammar, and repeated words for cleaner, more professional content ✏️
- Corrected technical descriptions in model comparison pages, including:
  - YOLO11 module references changed from `C2f` to `C3k2` where appropriate 🧠
  - YOLO11 parameter reduction vs YOLOv8 updated from 22% to 42% 📈
  - YOLOv7 wording adjusted to better describe its architecture and training approach
- Replaced several model “Docs” links from Ultralytics Platform pages to the proper documentation pages, especially for YOLO11, YOLO26, and YOLOv5 🌐
- Added Ultralytics Platform links in the comparison index for key models like YOLO26, YOLO11, YOLOv8, and YOLOv5 for easier model access 🚀
- Improved glossary/reference links, including using a clearer NMS glossary link and a more accurate augmented reality reference 🔍
- Simplified or corrected a few claims to avoid misleading wording, such as removing an unsupported FLOPs mention in the YOLO26 vs YOLOv7 comparison ⚖️
- Updated the README to reflect Python 3.8+ support instead of 3.9+ and made deployment guidance more generic and provider-friendly 📘
- Fixed a small typo in the GitHub Actions workflow comment (`Ultralics` → `Ultralytics`) ✅

### 🎯 Purpose & Impact
- Makes the docs more accurate and trustworthy for users comparing models or choosing deployment options 🤝
- Reduces confusion caused by outdated links, inconsistent terminology, or incorrect architectural details 🛠️
- Improves discoverability by better connecting docs pages with the Ultralytics Platform and official model documentation 🔗
- Helps developers follow setup instructions more confidently, especially with the corrected Python version requirement 💻
- Strengthens the overall polish of the docs site, which benefits both new users learning about YOLO models and experienced users looking for precise reference material 📚