### PR TITLE
Use blobless checkout in tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none # full commit/tag history for describe/log, no historical site blobs (gh-pages history is ~2GB)
           token: ${{ secrets._GITHUB_TOKEN }}
 
       - name: Git config


### PR DESCRIPTION
## Why

The Tag and Release workflow checks out with `fetch-depth: 0`, which on this repo fetches **all branches including the full gh-pages history of built-site snapshots: ~2.1 GB / 1,027,259 objects, measured at 141 s** — to run a handful of metadata-only git commands.

## What

Adds `filter: blob:none` to the checkout. Full commit and tag history is retained (required for `git describe`/`git log`/`git rev-list`); only blob downloads are skipped. Measured on the live repo: **4-5 s and 55-59 MB instead of 141 s and 2.1 GB (~30x faster, ~38x smaller)**.

Every git operation in this workflow and in `ultralytics-actions-summarize-release` is metadata-only, verified against the sources: `git rev-parse <tag>`, `git tag -a -m "$(git log -1 --pretty=%B)"`, `git push origin <tag>`, `git describe --tags --exclude`, `git rev-list --max-parents=0 HEAD`. The release diff/PR list comes from the GitHub API compare endpoint, not local git, so no file blobs are ever read.

Note: if a future step ever reads historical file contents (`git show <old>:<path>`, `git log -p`, content diffs), the partial clone will lazy-fetch those blobs over the network — functional, just slower for that step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚙️ This PR optimizes the tag workflow checkout step by fetching full Git history without downloading large historical file contents, making tagging jobs more efficient.

### 📊 Key Changes
- Added `filter: blob:none` to the `actions/checkout` step in `.github/workflows/tag.yml`.
- Kept `fetch-depth: 0`, so the workflow still has full commit and tag history available.
- Prevented downloading historical blob data, especially large `gh-pages` site history, which is noted to be around 2GB. 🚀

### 🎯 Purpose & Impact
- Improves workflow performance by reducing unnecessary data transfer during checkout.
- Keeps important Git operations like `describe` and `log` working correctly because full history is still available.
- Reduces bandwidth and storage usage in GitHub Actions, which can help workflows run faster and more reliably. 💡
- Particularly beneficial for repositories with heavy history, such as large generated site content in `gh-pages`.