### PR TITLE
Shorten compare page titles

### DIFF
--- a/docs/en/compare/damo-yolo-vs-efficientdet.md
+++ b/docs/en/compare/damo-yolo-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs EfficientDet Comparison
 comments: true
 description: Compare DAMO-YOLO and EfficientDet for object detection. Explore architectures, metrics, and use cases to select the right model for your needs.
 keywords: DAMO-YOLO, EfficientDet, object detection, model comparison, performance metrics, computer vision, YOLO, EfficientNet, BiFPN, NAS, COCO dataset

--- a/docs/en/compare/damo-yolo-vs-efficientdet.md
+++ b/docs/en/compare/damo-yolo-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare DAMO-YOLO and EfficientDet for object detection. Explore ar
 keywords: DAMO-YOLO, EfficientDet, object detection, model comparison, performance metrics, computer vision, YOLO, EfficientNet, BiFPN, NAS, COCO dataset
 ---
 
-# DAMO-YOLO vs EfficientDet: A Technical Deep Dive into Modern Object Detection
+# DAMO-YOLO vs EfficientDet
 
 The evolution of computer vision has produced an array of powerful architectures tailored for varying real-world demands. While some frameworks prioritize massive scalability, others focus heavily on real-time inference speed. In this technical comparison, we explore **DAMO-YOLO** and **EfficientDet**, two highly influential models that showcase distinct approaches to solving the object detection problem. We will dissect their architectures, compare their benchmark performances, and ultimately explore why the newly released Ultralytics YOLO26 represents the optimal choice for modern production deployments.
 

--- a/docs/en/compare/damo-yolo-vs-pp-yoloe.md
+++ b/docs/en/compare/damo-yolo-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs PP-YOLOE+ Comparison
 comments: true
 description: Compare DAMO-YOLO and PP-YOLOE+ for object detection. Discover strengths, weaknesses, and use cases to choose the best model for your projects.
 keywords: DAMO-YOLO, PP-YOLOE+, object detection, model comparison, computer vision, YOLO models, AI, deep learning, PaddlePaddle, NAS backbone

--- a/docs/en/compare/damo-yolo-vs-pp-yoloe.md
+++ b/docs/en/compare/damo-yolo-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare DAMO-YOLO and PP-YOLOE+ for object detection. Discover stre
 keywords: DAMO-YOLO, PP-YOLOE+, object detection, model comparison, computer vision, YOLO models, AI, deep learning, PaddlePaddle, NAS backbone
 ---
 
-# DAMO-YOLO vs PP-YOLOE+: A Detailed Technical Comparison
+# DAMO-YOLO vs PP-YOLOE+
 
 In the highly competitive landscape of real-time computer vision, choosing the optimal architecture for your specific deployment needs is crucial. This guide provides a comprehensive technical comparison between **DAMO-YOLO** and **PP-YOLOE+**, diving deep into their architectural designs, training methodologies, and performance metrics. We will also examine how these models stack up against state-of-the-art solutions like the newly released Ultralytics YOLO26.
 

--- a/docs/en/compare/damo-yolo-vs-rtdetr.md
+++ b/docs/en/compare/damo-yolo-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare DAMO-YOLO and RTDETRv2 performance, accuracy, and use cases
 keywords: DAMO-YOLO, RTDETRv2, object detection, YOLO models, real-time detection, transformer models, computer vision, model comparison, AI, machine learning
 ---
 
-# A Technical Showdown: DAMO-YOLO vs RTDETRv2 for Real-Time Object Detection
+# DAMO-YOLO vs RTDETRv2
 
 The rapidly evolving landscape of computer vision has produced an impressive array of architectures designed to balance speed, accuracy, and computational efficiency. Two standout models that have contributed unique approaches to solving these challenges are DAMO-YOLO and RTDETRv2. While both models aim to provide cutting-edge solutions for real-time inference, they fundamentally differ in their architectural philosophies.
 

--- a/docs/en/compare/damo-yolo-vs-rtdetr.md
+++ b/docs/en/compare/damo-yolo-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs RTDETRv2 Comparison
 comments: true
 description: Compare DAMO-YOLO and RTDETRv2 performance, accuracy, and use cases. Explore insights for efficient and high-accuracy object detection in real-time.
 keywords: DAMO-YOLO, RTDETRv2, object detection, YOLO models, real-time detection, transformer models, computer vision, model comparison, AI, machine learning

--- a/docs/en/compare/damo-yolo-vs-yolo11.md
+++ b/docs/en/compare/damo-yolo-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLO11 Comparison
 comments: true
 description: Compare Ultralytics YOLO11 and DAMO-YOLO models in performance, architecture, and use cases. Discover the best fit for your computer vision needs.
 keywords: YOLO11, DAMO-YOLO,object detection, Ultralytics,Deep Learning, Computer Vision, Model Comparison, Neural Networks, Performance Metrics, AI Models

--- a/docs/en/compare/damo-yolo-vs-yolo11.md
+++ b/docs/en/compare/damo-yolo-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO11 and DAMO-YOLO models in performance, arc
 keywords: YOLO11, DAMO-YOLO,object detection, Ultralytics,Deep Learning, Computer Vision, Model Comparison, Neural Networks, Performance Metrics, AI Models
 ---
 
-# DAMO-YOLO vs YOLO11: A Comprehensive Technical Comparison
+# DAMO-YOLO vs YOLO11
 
 When choosing a real-time object detection architecture for your next computer vision project, understanding the nuances between leading models is critical. This comprehensive guide provides an in-depth technical analysis comparing DAMO-YOLO and Ultralytics YOLO11, exploring their architectures, performance metrics, training methodologies, and ideal real-world deployment scenarios.
 

--- a/docs/en/compare/damo-yolo-vs-yolo26.md
+++ b/docs/en/compare/damo-yolo-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare DAMO-YOLO and YOLO26 for object detection. Explore architec
 keywords: DAMO-YOLO,YOLO26,object detection,DAMO-YOLOm,YOLO26,AI models,computer vision,model comparison,efficient AI,deep learning
 ---
 
-# DAMO-YOLO vs. YOLO26: Analyzing Next-Gen Real-Time Object Detection Architectures
+# DAMO-YOLO vs YOLO26
 
 The landscape of computer vision is constantly evolving, driven by the need for architectures that balance high accuracy with low-latency inference. This comparison delves into the technical intricacies of **DAMO-YOLO** and **Ultralytics YOLO26**, exploring their architectural innovations, training methodologies, and ideal use cases.
 

--- a/docs/en/compare/damo-yolo-vs-yolo26.md
+++ b/docs/en/compare/damo-yolo-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLO26 Comparison
 comments: true
 description: Compare DAMO-YOLO and YOLO26 for object detection. Explore architectures, benchmarks, and use cases to select the best model for your needs.
 keywords: DAMO-YOLO,YOLO26,object detection,DAMO-YOLOm,YOLO26,AI models,computer vision,model comparison,efficient AI,deep learning

--- a/docs/en/compare/damo-yolo-vs-yolov10.md
+++ b/docs/en/compare/damo-yolo-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and DAMO-YOLO object detection models. Explore arch
 keywords: YOLOv10, DAMO-YOLO, object detection comparison, YOLO models, DAMO-YOLO performance, YOLOv10 features, computer vision models, real-time object detection
 ---
 
-# DAMO-YOLO vs YOLOv10: Evolution of Efficient Real-Time Object Detection
+# DAMO-YOLO vs YOLOv10
 
 The field of computer vision has witnessed a rapid evolution in real-time [object detection](https://docs.ultralytics.com/tasks/detect) architectures. When comparing **DAMO-YOLO** and **YOLOv10**, we observe two distinct philosophies in model design: automated architecture search versus end-to-end NMS-free optimization. While both push the boundaries of accuracy and speed, their underlying structures and ideal use cases differ significantly.
 

--- a/docs/en/compare/damo-yolo-vs-yolov10.md
+++ b/docs/en/compare/damo-yolo-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv10 Comparison
 comments: true
 description: Compare YOLOv10 and DAMO-YOLO object detection models. Explore architectures, performance metrics, and ideal use cases for your computer vision needs.
 keywords: YOLOv10, DAMO-YOLO, object detection comparison, YOLO models, DAMO-YOLO performance, YOLOv10 features, computer vision models, real-time object detection

--- a/docs/en/compare/damo-yolo-vs-yolov5.md
+++ b/docs/en/compare/damo-yolo-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv5 Comparison
 comments: true
 description: Explore a detailed comparison of DAMO-YOLO and YOLOv5, covering architecture, performance, and use cases to help select the best model for your project.
 keywords: DAMO-YOLO, YOLOv5, object detection, model comparison, deep learning, computer vision, accuracy, performance metrics, Ultralytics

--- a/docs/en/compare/damo-yolo-vs-yolov5.md
+++ b/docs/en/compare/damo-yolo-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of DAMO-YOLO and YOLOv5, covering arc
 keywords: DAMO-YOLO, YOLOv5, object detection, model comparison, deep learning, computer vision, accuracy, performance metrics, Ultralytics
 ---
 
-# DAMO-YOLO vs. YOLOv5: A Deep Dive into Real-Time Object Detection
+# DAMO-YOLO vs YOLOv5
 
 The evolution of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has been marked by continuous innovation in real-time object detection. Today, developers and researchers are faced with a myriad of architectural choices when designing vision pipelines. This comprehensive technical comparison explores the nuances between **DAMO-YOLO** and **Ultralytics YOLOv5**, highlighting their respective architectures, training methodologies, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/damo-yolo-vs-yolov6.md
+++ b/docs/en/compare/damo-yolo-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Compare DAMO-YOLO and YOLOv6-3.0 for object detection. Discover the
 keywords: DAMO-YOLO, YOLOv6-3.0, object detection, model comparison, real-time detection, performance metrics, computer vision, architecture, scalability
 ---
 
-# DAMO-YOLO vs YOLOv6-3.0: A Comprehensive Comparison of Industrial Object Detectors
+# DAMO-YOLO vs YOLOv6-3.0
 
 The rapid evolution of computer vision has produced highly specialized architectures tailored for industrial applications. Among these, two heavyweights stand out for their focus on real-time performance and deployment efficiency: **DAMO-YOLO** and **YOLOv6-3.0**. This page provides an in-depth technical comparison of their architectures, performance metrics, and training methodologies to help you navigate your deployment choices.
 

--- a/docs/en/compare/damo-yolo-vs-yolov6.md
+++ b/docs/en/compare/damo-yolo-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv6-3.0 Comparison
 comments: true
 description: Compare DAMO-YOLO and YOLOv6-3.0 for object detection. Discover their architectures, performance, and use cases to choose the best model for your needs.
 keywords: DAMO-YOLO, YOLOv6-3.0, object detection, model comparison, real-time detection, performance metrics, computer vision, architecture, scalability

--- a/docs/en/compare/damo-yolo-vs-yolov7.md
+++ b/docs/en/compare/damo-yolo-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Detailed comparison of DAMO-YOLO vs YOLOv7 for object detection. An
 keywords: DAMO-YOLO, YOLOv7, object detection, model comparison, computer vision, deep learning, performance analysis, AI models
 ---
 
-# DAMO-YOLO vs YOLOv7: Evaluating Real-Time Object Detectors
+# DAMO-YOLO vs YOLOv7
 
 The rapid evolution of computer vision has produced highly efficient [object detection](https://docs.ultralytics.com/tasks/detect) models designed to balance precision and computational cost. Two notable models introduced in 2022 are **DAMO-YOLO** and **YOLOv7**. While both aim to push the boundaries of real-time vision tasks, they achieve their results through vastly different architectural paradigms and training methodologies.
 

--- a/docs/en/compare/damo-yolo-vs-yolov7.md
+++ b/docs/en/compare/damo-yolo-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv7 Comparison
 comments: true
 description: Detailed comparison of DAMO-YOLO vs YOLOv7 for object detection. Analyze performance, architecture, and use cases to choose the best model for your needs.
 keywords: DAMO-YOLO, YOLOv7, object detection, model comparison, computer vision, deep learning, performance analysis, AI models

--- a/docs/en/compare/damo-yolo-vs-yolov8.md
+++ b/docs/en/compare/damo-yolo-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Discover the key differences between DAMO-YOLO and YOLOv8. Compare 
 keywords: DAMO-YOLO, YOLOv8, object detection, model comparison, accuracy, speed, AI, deep learning, computer vision, YOLO models
 ---
 
-# DAMO-YOLO vs. Ultralytics YOLOv8: A Comprehensive Technical Comparison
+# DAMO-YOLO vs YOLOv8
 
 The landscape of real-time computer vision is constantly shifting as researchers and engineers push the boundaries of speed and accuracy. Two significant milestones in this journey are **DAMO-YOLO** and **Ultralytics YOLOv8**. While both models aim to optimize the trade-off between latency and mean Average Precision (mAP), they take fundamentally different architectural and philosophical approaches to solving [object detection](https://en.wikipedia.org/wiki/Object_detection) challenges.
 

--- a/docs/en/compare/damo-yolo-vs-yolov8.md
+++ b/docs/en/compare/damo-yolo-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv8 Comparison
 comments: true
 description: Discover the key differences between DAMO-YOLO and YOLOv8. Compare accuracy, speed, architecture, and use cases to choose the best object detection model.
 keywords: DAMO-YOLO, YOLOv8, object detection, model comparison, accuracy, speed, AI, deep learning, computer vision, YOLO models

--- a/docs/en/compare/damo-yolo-vs-yolov9.md
+++ b/docs/en/compare/damo-yolo-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison between DAMO-YOLO and YOLOv
 keywords: DAMO-YOLO, YOLOv9, object detection, model comparison, YOLO series, deep learning, computer vision, mAP, real-time detection
 ---
 
-# DAMO-YOLO vs. YOLOv9: A Comprehensive Technical Comparison of Modern Object Detection Architectures
+# DAMO-YOLO vs YOLOv9
 
 The landscape of real-time object detection continues to evolve at a breakneck pace. As engineering teams and researchers strive for the perfect balance of accuracy, inference speed, and computational efficiency, two notable architectures have emerged from the research community: **DAMO-YOLO** and **YOLOv9**. Both models introduce significant architectural innovations aimed at pushing the boundaries of what is possible in computer vision.
 

--- a/docs/en/compare/damo-yolo-vs-yolov9.md
+++ b/docs/en/compare/damo-yolo-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOv9 Comparison
 comments: true
 description: Explore a detailed technical comparison between DAMO-YOLO and YOLOv9, covering architecture, performance, and use cases for object detection applications.
 keywords: DAMO-YOLO, YOLOv9, object detection, model comparison, YOLO series, deep learning, computer vision, mAP, real-time detection

--- a/docs/en/compare/damo-yolo-vs-yolox.md
+++ b/docs/en/compare/damo-yolo-vs-yolox.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of DAMO-YOLO and YOLOX, analyzing arc
 keywords: DAMO-YOLO, YOLOX, object detection, model comparison, YOLO, computer vision, NAS backbone, RepGFPN, ZeroHead, SimOTA, anchor-free detection
 ---
 
-# DAMO-YOLO vs. YOLOX: A Comprehensive Technical Comparison
+# DAMO-YOLO vs YOLOX
 
 The landscape of real-time computer vision is constantly evolving. Two notable milestones in this journey are **DAMO-YOLO** and **YOLOX**, each bringing unique innovations to the problem of high-speed, high-accuracy object detection. While both models have contributed significantly to the open-source community, understanding their architectural differences, training methodologies, and ideal deployment scenarios is crucial for machine learning engineers.
 

--- a/docs/en/compare/damo-yolo-vs-yolox.md
+++ b/docs/en/compare/damo-yolo-vs-yolox.md
@@ -37,7 +37,7 @@ Organization: [Megvii](https://en.megvii.com/)
 Date: 2021-07-18  
 Arxiv: [https://arxiv.org/abs/2107.08430](https://arxiv.org/abs/2107.08430)  
 GitHub: [https://github.com/Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)  
-Docs: [YOLOX Documentation](https://yolox.readthedocs.io/en/latest/)
+Docs: [YOLOX Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 [Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX){ .md-button }
 

--- a/docs/en/compare/damo-yolo-vs-yolox.md
+++ b/docs/en/compare/damo-yolo-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: DAMO-YOLO vs YOLOX Comparison
 comments: true
 description: Explore a detailed comparison of DAMO-YOLO and YOLOX, analyzing architecture, performance, and use cases for object detection applications.
 keywords: DAMO-YOLO, YOLOX, object detection, model comparison, YOLO, computer vision, NAS backbone, RepGFPN, ZeroHead, SimOTA, anchor-free detection

--- a/docs/en/compare/efficientdet-vs-damo-yolo.md
+++ b/docs/en/compare/efficientdet-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet and DAMO-YOLO object detection models in terms
 keywords: EfficientDet, DAMO-YOLO, object detection, model comparison, EfficientNet, BiFPN, real-time inference, AI, computer vision, deep learning, Ultralytics
 ---
 
-# EfficientDet vs DAMO-YOLO: A Technical Comparison of Object Detection Architectures
+# EfficientDet vs DAMO-YOLO
 
 When building scalable [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipelines, selecting the right model architecture is a critical decision that influences both deployment feasibility and detection accuracy. This guide provides an in-depth, technical comparison between two well-known architectures in the visual recognition landscape: EfficientDet and DAMO-YOLO.
 

--- a/docs/en/compare/efficientdet-vs-damo-yolo.md
+++ b/docs/en/compare/efficientdet-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs DAMO-YOLO Comparison
 comments: true
 description: Compare EfficientDet and DAMO-YOLO object detection models in terms of accuracy, speed, and efficiency for real-time and resource-constrained applications.
 keywords: EfficientDet, DAMO-YOLO, object detection, model comparison, EfficientNet, BiFPN, real-time inference, AI, computer vision, deep learning, Ultralytics

--- a/docs/en/compare/efficientdet-vs-pp-yoloe.md
+++ b/docs/en/compare/efficientdet-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet and PP-YOLOE+ for object detection. Explore ar
 keywords: EfficientDet, PP-YOLOE+, object detection, model comparison, EfficientDet features, PP-YOLOE+ benefits, Ultralytics models, computer vision, AI benchmarks
 ---
 
-# EfficientDet vs PP-YOLOE+: A Technical Deep Dive into Object Detection Architectures
+# EfficientDet vs PP-YOLOE+
 
 The landscape of computer vision has been heavily shaped by the continuous evolution of object detection models. Two significant milestones in this journey are Google's EfficientDet and Baidu's PP-YOLOE+. While both architectures were designed to balance the delicate trade-off between computational efficiency and detection accuracy, they approach this challenge through fundamentally different design philosophies.
 

--- a/docs/en/compare/efficientdet-vs-pp-yoloe.md
+++ b/docs/en/compare/efficientdet-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs PP-YOLOE+ Comparison
 comments: true
 description: Compare EfficientDet and PP-YOLOE+ for object detection. Explore architectures, performance, scalability, and real-world applications. Learn more now!.
 keywords: EfficientDet, PP-YOLOE+, object detection, model comparison, EfficientDet features, PP-YOLOE+ benefits, Ultralytics models, computer vision, AI benchmarks

--- a/docs/en/compare/efficientdet-vs-rtdetr.md
+++ b/docs/en/compare/efficientdet-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs RTDETRv2 Comparison
 comments: true
 description: Explore a detailed comparison of EfficientDet and RTDETRv2. Compare performance, architecture, and use cases to choose the right object detection model.
 keywords: EfficientDet, RTDETRv2, object detection, Ultralytics, EfficientDet comparison, RTDETRv2 comparison, computer vision, model performance

--- a/docs/en/compare/efficientdet-vs-rtdetr.md
+++ b/docs/en/compare/efficientdet-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of EfficientDet and RTDETRv2. Compare
 keywords: EfficientDet, RTDETRv2, object detection, Ultralytics, EfficientDet comparison, RTDETRv2 comparison, computer vision, model performance
 ---
 
-# EfficientDet vs RTDETRv2: An In-Depth Comparison of Object Detection Architectures
+# EfficientDet vs RTDETRv2
 
 Choosing the optimal architecture for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) projects requires navigating a diverse landscape of neural networks. This guide explores a detailed technical comparison between two distinct approaches: EfficientDet, a highly scalable Convolutional Neural Network (CNN) family, and RTDETRv2, a state-of-the-art real-time transformer model. We evaluate their structural differences, training methodologies, and deployment suitability across various hardware environments.
 

--- a/docs/en/compare/efficientdet-vs-yolo11.md
+++ b/docs/en/compare/efficientdet-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLO11 and EfficientDet, analyzing
 keywords: YOLO11, EfficientDet, model comparison, object detection, Ultralytics, EfficientDet-Dx, YOLO performance, computer vision, real-time detection, AI models
 ---
 
-# EfficientDet vs YOLO11: A Comprehensive Technical Comparison
+# EfficientDet vs YOLO11
 
 Selecting the optimal neural network architecture is the foundation of any successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) application. This comprehensive guide provides an in-depth technical comparison between Google's EfficientDet and [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11), analyzing their architectural differences, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/efficientdet-vs-yolo11.md
+++ b/docs/en/compare/efficientdet-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLO11 Comparison
 comments: true
 description: Explore a detailed comparison of YOLO11 and EfficientDet, analyzing architecture, performance, and use cases to guide your object detection model choice.
 keywords: YOLO11, EfficientDet, model comparison, object detection, Ultralytics, EfficientDet-Dx, YOLO performance, computer vision, real-time detection, AI models

--- a/docs/en/compare/efficientdet-vs-yolo26.md
+++ b/docs/en/compare/efficientdet-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLO26 Comparison
 comments: true
 description: Compare EfficientDet and YOLO26 for object detection. Explore architecture, performance, and use cases to make an informed choice for your projects.
 keywords: EfficientDet, YOLO26, object detection, model comparison, BiFPN, NMS-free, computer vision, real-time detection, efficient models, Ultralytics

--- a/docs/en/compare/efficientdet-vs-yolo26.md
+++ b/docs/en/compare/efficientdet-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet and YOLO26 for object detection. Explore archi
 keywords: EfficientDet, YOLO26, object detection, model comparison, BiFPN, NMS-free, computer vision, real-time detection, efficient models, Ultralytics
 ---
 
-# EfficientDet vs. YOLO26: A Comprehensive Technical Comparison
+# EfficientDet vs YOLO26
 
 Choosing the right computer vision architecture is a critical step in building scalable and efficient AI systems. This comprehensive guide provides an in-depth technical comparison between Google's legacy EfficientDet and the state-of-the-art [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26). We evaluate their underlying architectures, performance metrics, and training methodologies to help you select the best model for your specific deployment constraints.
 

--- a/docs/en/compare/efficientdet-vs-yolov10.md
+++ b/docs/en/compare/efficientdet-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv10 Comparison
 comments: true
 description: Compare EfficientDet and YOLOv10 for object detection. Explore their architectures, performance, strengths, and use cases to find the ideal model.
 keywords: EfficientDet,YOLOv10,object detection,model comparison,computer vision,real-time detection,scalability,model accuracy,inference speed

--- a/docs/en/compare/efficientdet-vs-yolov10.md
+++ b/docs/en/compare/efficientdet-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet and YOLOv10 for object detection. Explore thei
 keywords: EfficientDet,YOLOv10,object detection,model comparison,computer vision,real-time detection,scalability,model accuracy,inference speed
 ---
 
-# EfficientDet vs YOLOv10: Analyzing the Evolution of Object Detection Models
+# EfficientDet vs YOLOv10
 
 In the rapidly evolving field of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv), choosing the right object detection architecture is critical for balancing accuracy, latency, and computational efficiency. This comprehensive technical guide compares two highly influential models: Google's **EfficientDet** and Tsinghua University's **YOLOv10**. While both models represent significant leaps in object detection, they approach architectural design and [model optimization](https://www.ultralytics.com/blog/what-is-model-optimization-a-quick-guide) from vastly different angles.
 

--- a/docs/en/compare/efficientdet-vs-yolov5.md
+++ b/docs/en/compare/efficientdet-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of EfficientDet and YOLOv5.
 keywords: EfficientDet, YOLOv5, object detection, model comparison, computer vision, Ultralytics, performance metrics, inference speed, mAP, architecture
 ---
 
-# EfficientDet vs YOLOv5: A Comprehensive Technical Comparison
+# EfficientDet vs YOLOv5
 
 Selecting the optimal neural network architecture is a defining step in any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) initiative. The balance between inference latency, parameter efficiency, and detection accuracy dictates how well a model will perform in the real world. This comprehensive technical guide provides an in-depth analysis of two highly influential object detection frameworks: Google's EfficientDet and Ultralytics YOLOv5.
 

--- a/docs/en/compare/efficientdet-vs-yolov5.md
+++ b/docs/en/compare/efficientdet-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv5 Comparison
 comments: true
 description: Explore a detailed technical comparison of EfficientDet and YOLOv5. Learn their strengths, weaknesses, and ideal use cases for object detection.
 keywords: EfficientDet, YOLOv5, object detection, model comparison, computer vision, Ultralytics, performance metrics, inference speed, mAP, architecture

--- a/docs/en/compare/efficientdet-vs-yolov6.md
+++ b/docs/en/compare/efficientdet-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Explore EfficientDet and YOLOv6-3.0 in a detailed comparison coveri
 keywords: EfficientDet, YOLOv6, object detection, computer vision, model comparison, EfficientNet, BiFPN, real-time detection, performance benchmarks
 ---
 
-# EfficientDet vs YOLOv6-3.0: A Comprehensive Guide to Industrial Object Detection
+# EfficientDet vs YOLOv6-3.0
 
 Choosing the right neural network architecture is the cornerstone of any successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) initiative. This deep dive provides a highly technical comparison between two pivotal models in the [object detection](https://docs.ultralytics.com/tasks/detect) landscape: Google's EfficientDet and Meituan's YOLOv6-3.0.
 

--- a/docs/en/compare/efficientdet-vs-yolov6.md
+++ b/docs/en/compare/efficientdet-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv6-3.0 Comparison
 comments: true
 description: Explore EfficientDet and YOLOv6-3.0 in a detailed comparison covering architecture, accuracy, speed, and best use cases to choose the right model for your needs.
 keywords: EfficientDet, YOLOv6, object detection, computer vision, model comparison, EfficientNet, BiFPN, real-time detection, performance benchmarks

--- a/docs/en/compare/efficientdet-vs-yolov7.md
+++ b/docs/en/compare/efficientdet-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv7 Comparison
 comments: true
 description: Discover key differences between EfficientDet and YOLOv7 models. Explore architecture, performance, and use cases to choose the best object detection model.
 keywords: EfficientDet, YOLOv7, object detection, model comparison, EfficientDet vs YOLOv7, accuracy, speed, machine learning, computer vision, Ultralytics documentation

--- a/docs/en/compare/efficientdet-vs-yolov7.md
+++ b/docs/en/compare/efficientdet-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Discover key differences between EfficientDet and YOLOv7 models. Ex
 keywords: EfficientDet, YOLOv7, object detection, model comparison, EfficientDet vs YOLOv7, accuracy, speed, machine learning, computer vision, Ultralytics documentation
 ---
 
-# EfficientDet vs YOLOv7: Navigating Real-Time Object Detection Architectures
+# EfficientDet vs YOLOv7
 
 Selecting the most effective neural network architecture is critical to the success of any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) initiative. As the demand for high-performance AI solutions accelerates, comparing established models like EfficientDet and YOLOv7 becomes essential for developers aiming to optimize both accuracy and computational efficiency.
 

--- a/docs/en/compare/efficientdet-vs-yolov8.md
+++ b/docs/en/compare/efficientdet-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet vs YOLOv8 for object detection. Explore their 
 keywords: EfficientDet, YOLOv8, model comparison, object detection, computer vision, machine learning, EfficientDet vs YOLOv8, Ultralytics models, real-time detection
 ---
 
-# EfficientDet vs YOLOv8: A Technical Comparison of Object Detection Architectures
+# EfficientDet vs YOLOv8
 
 The field of [computer vision](https://en.wikipedia.org/wiki/Computer_vision) is constantly evolving, with new architectures frequently pushing the boundaries of what is possible. Choosing the right neural network architecture is critical for balancing accuracy, latency, and resource consumption. In this comprehensive technical analysis, we will compare two powerhouse models in the object detection arena: **EfficientDet** by Google and **Ultralytics YOLOv8**.
 

--- a/docs/en/compare/efficientdet-vs-yolov8.md
+++ b/docs/en/compare/efficientdet-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv8 Comparison
 comments: true
 description: Compare EfficientDet vs YOLOv8 for object detection. Explore their architecture, performance, and ideal use cases to make an informed choice.
 keywords: EfficientDet, YOLOv8, model comparison, object detection, computer vision, machine learning, EfficientDet vs YOLOv8, Ultralytics models, real-time detection

--- a/docs/en/compare/efficientdet-vs-yolov9.md
+++ b/docs/en/compare/efficientdet-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOv9 Comparison
 comments: true
 description: Compare EfficientDet and YOLOv9 models in accuracy, speed, and use cases. Learn which object detection model suits your vision project best.
 keywords: EfficientDet, YOLOv9, object detection comparison, computer vision, model performance, AI benchmarks, real-time detection, edge deployments

--- a/docs/en/compare/efficientdet-vs-yolov9.md
+++ b/docs/en/compare/efficientdet-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare EfficientDet and YOLOv9 models in accuracy, speed, and use 
 keywords: EfficientDet, YOLOv9, object detection comparison, computer vision, model performance, AI benchmarks, real-time detection, edge deployments
 ---
 
-# EfficientDet vs. YOLOv9: Architecture, Performance, and Edge Deployment
+# EfficientDet vs YOLOv9
 
 The landscape of computer vision has been shaped by continuous breakthroughs in neural network design. Finding the right balance between computational efficiency and detection accuracy is critical when selecting a model. Google's **EfficientDet** established a strong baseline in 2019 by introducing scalable architectures, while **YOLOv9**, released in 2024, pushed the boundaries of [object detection](https://docs.ultralytics.com/tasks/detect) using Programmable Gradient Information (PGI).
 

--- a/docs/en/compare/efficientdet-vs-yolox.md
+++ b/docs/en/compare/efficientdet-vs-yolox.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of EfficientDet and YOLOX models. Lea
 keywords: EfficientDet, YOLOX, object detection, model comparison, EfficientDet vs YOLOX, machine learning, computer vision, deep learning, neural networks, object detection models
 ---
 
-# EfficientDet vs YOLOX: A Comprehensive Object Detection Comparison
+# EfficientDet vs YOLOX
 
 When architecting a modern [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipeline, selecting the right model is a critical decision that dictates both accuracy and real-time viability. This technical guide provides an in-depth comparison between two pivotal architectures in the evolution of neural networks: Google's EfficientDet and Megvii's YOLOX. We will analyze their architectural paradigms, evaluate their benchmarked performance, and explore how they measure up against state-of-the-art solutions like the newly released [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26).
 

--- a/docs/en/compare/efficientdet-vs-yolox.md
+++ b/docs/en/compare/efficientdet-vs-yolox.md
@@ -45,7 +45,7 @@ Released two years later, YOLOX sought to bridge the gap between academic resear
 - **Date:** 2021-07-18
 - **ArXiv:** [2107.08430](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Docs:** [YOLOX Documentation](https://yolox.readthedocs.io/en/latest/)
+- **Docs:** [YOLOX Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architectural Highlights
 
@@ -53,7 +53,7 @@ YOLOX significantly simplified the object detection paradigm. By switching to an
 
 Despite these advancements, managing YOLOX repositories often requires compiling manual C++ extensions and navigating complex dependencies, which can hinder rapid [model deployment](https://docs.ultralytics.com/guides/model-deployment-options) for less experienced teams.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 ## Performance Comparison
 

--- a/docs/en/compare/efficientdet-vs-yolox.md
+++ b/docs/en/compare/efficientdet-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: EfficientDet vs YOLOX Comparison
 comments: true
 description: Explore a detailed comparison of EfficientDet and YOLOX models. Learn about their architectures, performance, use cases, and which fits your needs best.
 keywords: EfficientDet, YOLOX, object detection, model comparison, EfficientDet vs YOLOX, machine learning, computer vision, deep learning, neural networks, object detection models

--- a/docs/en/compare/index.md
+++ b/docs/en/compare/index.md
@@ -4,7 +4,7 @@ description: Explore comprehensive comparisons of Ultralytics YOLO26, YOLO11, YO
 keywords: YOLO26, YOLO11, YOLOv10 comparison, YOLOv8 vs RT-DETR, object detection benchmarks, computer vision models, AI model selection, Ultralytics Platform, speed vs accuracy
 ---
 
-# Model Comparisons: Choose the Best Object Detection Model for Your Project
+# Model Comparisons
 
 Choosing the right neural network architecture is the cornerstone of any successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project. Welcome to the **Ultralytics Model Comparison Hub**! This page centralizes detailed technical analyses and performance benchmarks, dissecting the trade-offs between the latest [Ultralytics YOLO26](https://docs.ultralytics.com/models/yolo26) and other leading architectures like YOLO11, YOLOv10, RT-DETR, and EfficientDet.
 

--- a/docs/en/compare/pp-yoloe-vs-damo-yolo.md
+++ b/docs/en/compare/pp-yoloe-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs DAMO-YOLO Comparison
 comments: true
 description: Compare PP-YOLOE+ and DAMO-YOLO for object detection. Learn their strengths, weaknesses, and performance metrics to choose the right model.
 keywords: PP-YOLOE+, DAMO-YOLO, object detection, model comparison, computer vision, PaddlePaddle, Neural Architecture Search, Ultralytics YOLO, AI performance

--- a/docs/en/compare/pp-yoloe-vs-damo-yolo.md
+++ b/docs/en/compare/pp-yoloe-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and DAMO-YOLO for object detection. Learn their s
 keywords: PP-YOLOE+, DAMO-YOLO, object detection, model comparison, computer vision, PaddlePaddle, Neural Architecture Search, Ultralytics YOLO, AI performance
 ---
 
-# PP-YOLOE+ vs. DAMO-YOLO: A Comprehensive Technical Comparison
+# PP-YOLOE+ vs DAMO-YOLO
 
 The continuous evolution of computer vision has produced an array of highly specialized architectures for real-time object detection. When evaluating models for industrial and research applications, two prominent frameworks from 2022 often enter the discussion: **PP-YOLOE+** by Baidu and **DAMO-YOLO** by Alibaba Group. Both models pushed the boundaries of anchor-free detection by introducing novel backbones, advanced label assignment strategies, and specialized feature fusion techniques.
 

--- a/docs/en/compare/pp-yoloe-vs-efficientdet.md
+++ b/docs/en/compare/pp-yoloe-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and EfficientDet for object detection. Explore ar
 keywords: PP-YOLOE+,EfficientDet,object detection,PP-YOLOE+m,EfficientDet-D7,AI models,computer vision,model comparison,efficient AI,deep learning
 ---
 
-# PP-YOLOE+ vs EfficientDet: A Comprehensive Technical Comparison
+# PP-YOLOE+ vs EfficientDet
 
 Choosing the right architecture is a critical step in building robust [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) applications. This technical guide explores the trade-offs between two well-known object detection models: **PP-YOLOE+** and **EfficientDet**. We will break down their architectures, analyze their [performance metrics](https://docs.ultralytics.com/guides/yolo-performance-metrics), and explore their ideal deployment scenarios.
 

--- a/docs/en/compare/pp-yoloe-vs-efficientdet.md
+++ b/docs/en/compare/pp-yoloe-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs EfficientDet Comparison
 comments: true
 description: Compare PP-YOLOE+ and EfficientDet for object detection. Explore architectures, benchmarks, and use cases to select the best model for your needs.
 keywords: PP-YOLOE+,EfficientDet,object detection,PP-YOLOE+m,EfficientDet-D7,AI models,computer vision,model comparison,efficient AI,deep learning

--- a/docs/en/compare/pp-yoloe-vs-rtdetr.md
+++ b/docs/en/compare/pp-yoloe-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of PP-YOLOE+ and RTDETRv2 object dete
 keywords: PP-YOLOE+, RTDETRv2, object detection, model comparison, real-time detection, anchor-free detection, transformers, ultralytics, computer vision
 ---
 
-# PP-YOLOE+ vs RTDETRv2: A Comprehensive Guide to Real-Time Object Detection Architectures
+# PP-YOLOE+ vs RTDETRv2
 
 The field of computer vision has witnessed a dramatic evolution in recent years, particularly in the realm of real-time object detection. Choosing the right architecture for your deployment can mean the difference between a sluggish, memory-heavy application and a highly optimized, responsive system. In this technical comparison, we explore two prominent models from Baidu: the CNN-based PP-YOLOE+ and the transformer-based RTDETRv2. We will analyze their architectures, performance metrics, and ideal use cases, while also examining how they compare to the state-of-the-art [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) platform.
 

--- a/docs/en/compare/pp-yoloe-vs-rtdetr.md
+++ b/docs/en/compare/pp-yoloe-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs RTDETRv2 Comparison
 comments: true
 description: Explore a detailed comparison of PP-YOLOE+ and RTDETRv2 object detection models, analyzing performance, accuracy, and use cases to guide your decision.
 keywords: PP-YOLOE+, RTDETRv2, object detection, model comparison, real-time detection, anchor-free detection, transformers, ultralytics, computer vision

--- a/docs/en/compare/pp-yoloe-vs-yolo11.md
+++ b/docs/en/compare/pp-yoloe-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and YOLO11 object detection models. Explore perfo
 keywords: PP-YOLOE+, YOLO11, object detection, model comparison, computer vision, Ultralytics, PaddlePaddle, real-time AI, accuracy, speed, inference
 ---
 
-# A Deep Dive into Real-Time Object Detection: PP-YOLOE+ vs YOLO11
+# PP-YOLOE+ vs YOLO11
 
 The landscape of computer vision is constantly evolving, driven by the need for faster, more accurate, and more efficient models. For developers and researchers tackling [object detection](https://docs.ultralytics.com/tasks/detect) tasks, choosing the right architecture is critical. In this comprehensive comparison, we will explore the nuances between two prominent models: **PP-YOLOE+** and **Ultralytics YOLO11**.
 

--- a/docs/en/compare/pp-yoloe-vs-yolo11.md
+++ b/docs/en/compare/pp-yoloe-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLO11 Comparison
 comments: true
 description: Compare PP-YOLOE+ and YOLO11 object detection models. Explore performance, strengths, weaknesses, and ideal use cases to make informed choices.
 keywords: PP-YOLOE+, YOLO11, object detection, model comparison, computer vision, Ultralytics, PaddlePaddle, real-time AI, accuracy, speed, inference

--- a/docs/en/compare/pp-yoloe-vs-yolo26.md
+++ b/docs/en/compare/pp-yoloe-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLO26 Comparison
 comments: true
 description: Compare PP-YOLOE+ and YOLO26 for object detection. Explore architecture, performance, strengths, and use cases to choose the right model.
 keywords: PP-YOLOE+, YOLO26, object detection, model comparison, computer vision, performance metrics, Ultralytics, real-time detection, deep learning

--- a/docs/en/compare/pp-yoloe-vs-yolo26.md
+++ b/docs/en/compare/pp-yoloe-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and YOLO26 for object detection. Explore architec
 keywords: PP-YOLOE+, YOLO26, object detection, model comparison, computer vision, performance metrics, Ultralytics, real-time detection, deep learning
 ---
 
-# PP-YOLOE+ vs YOLO26: A Deep Dive into Real-Time Object Detection Architectures
+# PP-YOLOE+ vs YOLO26
 
 The landscape of real-time computer vision has seen tremendous growth, driven by the need for scalable, efficient, and highly accurate object detection models. Two standout architectures in this space are **PP-YOLOE+**, a powerful detector from the [PaddlePaddle ecosystem](https://github.com/PaddlePaddle/PaddleDetection/), and **[Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26)**, the latest state-of-the-art model redefining edge deployment and training efficiency.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov10.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv10 Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLOv10 and PP-YOLOE+ object detection models. Learn their strengths, use cases, performance, and architecture.
 keywords: YOLOv10,PP-YOLOE+,object detection,model comparison,Ultralytics,YOLO,PP-YOLOE,computer vision,real-time object detection

--- a/docs/en/compare/pp-yoloe-vs-yolov10.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLOv10 and PP-YOLOE+ ob
 keywords: YOLOv10,PP-YOLOE+,object detection,model comparison,Ultralytics,YOLO,PP-YOLOE,computer vision,real-time object detection
 ---
 
-# PP-YOLOE+ vs YOLOv10: Navigating Real-Time Object Detection Architectures
+# PP-YOLOE+ vs YOLOv10
 
 The landscape of computer vision is constantly evolving, with new models pushing the boundaries of what is possible in real-time object detection. In this comprehensive technical comparison, we will examine **PP-YOLOE+** and **YOLOv10**, two highly capable architectures designed for different ecosystems. We will also explore how the broader landscape is shifting towards more unified, easy-to-use platforms like the [Ultralytics Platform](https://platform.ultralytics.com) and the state-of-the-art [YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) model.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov5.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv5 Comparison
 comments: true
 description: Compare PP-YOLOE+ and YOLOv5 with insights into architecture, performance, and use cases. Discover the best object detection model for your needs.
 keywords: PP-YOLOE+, YOLOv5, object detection, model comparison, Ultralytics, AI models, computer vision, anchor-free, performance metrics

--- a/docs/en/compare/pp-yoloe-vs-yolov5.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and YOLOv5 with insights into architecture, perfo
 keywords: PP-YOLOE+, YOLOv5, object detection, model comparison, Ultralytics, AI models, computer vision, anchor-free, performance metrics
 ---
 
-# PP-YOLOE+ vs YOLOv5: Navigating Object Detection Architectures
+# PP-YOLOE+ vs YOLOv5
 
 When choosing the right deep learning framework for computer vision, developers often find themselves comparing the capabilities of different architectures to find the perfect balance of speed, accuracy, and ease of deployment. In this deep dive, we will explore the technical nuances between PP-YOLOE+ and YOLOv5. By analyzing their architectures, performance metrics, and ideal deployment scenarios, you can make an informed decision for your next project, whether it involves real-time robotics, edge deployment, or cloud-based video analytics.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov6.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Discover the strengths, weaknesses, and performance metrics of PP-Y
 keywords: PP-YOLOE+, YOLOv6-3.0, object detection, model comparison, machine learning, computer vision, YOLO, PaddlePaddle, Meituan, anchor-free models
 ---
 
-# Navigating Object Detection: PP-YOLOE+ vs YOLOv6-3.0
+# PP-YOLOE+ vs YOLOv6-3.0
 
 The field of real-time [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has expanded rapidly, leading to highly specialized architectures optimized for diverse deployment scenarios. Developers frequently compare [PP-YOLOE+](https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.8.1/configs/ppyoloe/README.md) and [YOLOv6-3.0](https://docs.ultralytics.com/models/yolov6) when building applications that require a balance of high throughput and reliable accuracy. Both models brought substantial architectural improvements to the table upon their releases, focusing on enhancing inference speeds for industrial and edge applications.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov6.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv6-3.0 Comparison
 comments: true
 description: Discover the strengths, weaknesses, and performance metrics of PP-YOLOE+ and YOLOv6-3.0. Choose the best model for your object detection needs.
 keywords: PP-YOLOE+, YOLOv6-3.0, object detection, model comparison, machine learning, computer vision, YOLO, PaddlePaddle, Meituan, anchor-free models

--- a/docs/en/compare/pp-yoloe-vs-yolov7.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Explore a technical comparison of PP-YOLOE+ and YOLOv7 models, cove
 keywords: PP-YOLOE+, YOLOv7, object detection, AI models, comparison, computer vision, model architecture, performance analysis, real-time detection
 ---
 
-# PP-YOLOE+ vs YOLOv7: Navigating Real-Time Object Detection Architectures
+# PP-YOLOE+ vs YOLOv7
 
 When building computer vision pipelines, selecting the right object detection model is critical. Two significant architectures from 2022, PP-YOLOE+ and YOLOv7, introduced powerful advancements in real-time object detection. This technical comparison provides an in-depth look into their architectures, training methodologies, and real-world performance to help you make informed decisions for your applications.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov7.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv7 Comparison
 comments: true
 description: Explore a technical comparison of PP-YOLOE+ and YOLOv7 models, covering architecture, performance benchmarks, and best use cases for object detection.
 keywords: PP-YOLOE+, YOLOv7, object detection, AI models, comparison, computer vision, model architecture, performance analysis, real-time detection

--- a/docs/en/compare/pp-yoloe-vs-yolov8.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare PP-YOLOE+ and YOLOv8—two top object detection models. Dis
 keywords: PP-YOLOE+, YOLOv8, object detection, computer vision, model comparison, YOLO models, Ultralytics, PaddlePaddle, machine learning, AI
 ---
 
-# PP-YOLOE+ vs YOLOv8: A Technical Comparison of Real-Time Object Detectors
+# PP-YOLOE+ vs YOLOv8
 
 The demand for high-performance, real-time [computer vision](https://en.wikipedia.org/wiki/Computer_vision) models has driven rapid innovation across the AI industry. Selecting the right architecture can be the deciding factor between a successful, highly efficient deployment and a cumbersome, resource-heavy pipeline. This technical guide provides an in-depth comparison between **PP-YOLOE+** and **[Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8)**, exploring their underlying architectures, training efficiencies, and ideal deployment scenarios.
 

--- a/docs/en/compare/pp-yoloe-vs-yolov8.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv8 Comparison
 comments: true
 description: Compare PP-YOLOE+ and YOLOv8—two top object detection models. Discover their strengths, weaknesses, and ideal use cases for your applications.
 keywords: PP-YOLOE+, YOLOv8, object detection, computer vision, model comparison, YOLO models, Ultralytics, PaddlePaddle, machine learning, AI

--- a/docs/en/compare/pp-yoloe-vs-yolov9.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOv9 Comparison
 comments: true
 description: Explore the differences between PP-YOLOE+ and YOLOv9 with detailed architecture, performance benchmarks, and use case analysis for object detection.
 keywords: PP-YOLOE+, YOLOv9, object detection, model comparison, computer vision, anchor-free detector, programmable gradient information, AI models, benchmarking

--- a/docs/en/compare/pp-yoloe-vs-yolov9.md
+++ b/docs/en/compare/pp-yoloe-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Explore the differences between PP-YOLOE+ and YOLOv9 with detailed 
 keywords: PP-YOLOE+, YOLOv9, object detection, model comparison, computer vision, anchor-free detector, programmable gradient information, AI models, benchmarking
 ---
 
-# PP-YOLOE+ vs. YOLOv9: A Technical Deep Dive into Modern Object Detection
+# PP-YOLOE+ vs YOLOv9
 
 The landscape of real-time computer vision is constantly shifting, with researchers and developers continuously pushing the boundaries of accuracy and inference speed. When comparing [PP-YOLOE+](https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.8.1/configs/ppyoloe/README.md) and [YOLOv9](https://docs.ultralytics.com/models/yolov9), we are looking at two distinct philosophies in model architecture and ecosystem design.
 

--- a/docs/en/compare/pp-yoloe-vs-yolox.md
+++ b/docs/en/compare/pp-yoloe-vs-yolox.md
@@ -35,7 +35,7 @@ Before diving into the technical architectures, it is helpful to contextualize t
 - Date: 2021-07-18
 - Arxiv: [https://arxiv.org/abs/2107.08430](https://arxiv.org/abs/2107.08430)
 - GitHub: [https://github.com/Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- Docs: [YOLOX Official Documentation](https://yolox.readthedocs.io/en/latest/)
+- Docs: [YOLOX Official Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 [Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX){ .md-button }
 

--- a/docs/en/compare/pp-yoloe-vs-yolox.md
+++ b/docs/en/compare/pp-yoloe-vs-yolox.md
@@ -4,7 +4,7 @@ description: Discover the key differences between PP-YOLOE+ and YOLOX models in 
 keywords: PP-YOLOE+, YOLOX, object detection, anchor-free models, model comparison, performance benchmarks, decoupled detection head, machine learning, computer vision
 ---
 
-# PP-YOLOE+ vs YOLOX: Navigating the Evolution of Real-Time Object Detectors
+# PP-YOLOE+ vs YOLOX
 
 The landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has been significantly shaped by the rapid evolution of object detection models. Among the notable milestones in this journey are PP-YOLOE+ and YOLOX, two architectures that pushed the boundaries of real-time performance and accuracy. Understanding their architectural nuances, performance trade-offs, and ideal deployment scenarios is crucial for researchers and developers building the next generation of visual recognition systems.
 

--- a/docs/en/compare/pp-yoloe-vs-yolox.md
+++ b/docs/en/compare/pp-yoloe-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: PP-YOLOE+ vs YOLOX Comparison
 comments: true
 description: Discover the key differences between PP-YOLOE+ and YOLOX models in architecture, performance, and applications for streamlined object detection.
 keywords: PP-YOLOE+, YOLOX, object detection, anchor-free models, model comparison, performance benchmarks, decoupled detection head, machine learning, computer vision

--- a/docs/en/compare/rtdetr-vs-damo-yolo.md
+++ b/docs/en/compare/rtdetr-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs DAMO-YOLO Comparison
 comments: true
 description: Discover a detailed comparison of RTDETRv2 and DAMO-YOLO for object detection. Learn about their performance, strengths, and ideal use cases.
 keywords: RTDETRv2,DAMO-YOLO,object detection,model comparison,Ultralytics,computer vision,real-time detection,AI models,deep learning

--- a/docs/en/compare/rtdetr-vs-damo-yolo.md
+++ b/docs/en/compare/rtdetr-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Discover a detailed comparison of RTDETRv2 and DAMO-YOLO for object
 keywords: RTDETRv2,DAMO-YOLO,object detection,model comparison,Ultralytics,computer vision,real-time detection,AI models,deep learning
 ---
 
-# RTDETRv2 vs. DAMO-YOLO: A Comprehensive Guide to Modern Real-Time Object Detection
+# RTDETRv2 vs DAMO-YOLO
 
 The landscape of computer vision is constantly evolving, with researchers and engineers striving to build models that perfectly balance speed, accuracy, and efficiency. Two prominent architectures that have made significant waves in this space are RTDETRv2, developed by Baidu, and DAMO-YOLO, crafted by Alibaba Group. Both models push the boundaries of real-time [object detection](https://en.wikipedia.org/wiki/Object_detection), yet they adopt fundamentally different architectural philosophies to achieve their impressive results.
 

--- a/docs/en/compare/rtdetr-vs-efficientdet.md
+++ b/docs/en/compare/rtdetr-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Explore RTDETRv2 vs EfficientDet for object detection with insights
 keywords: RTDETRv2, EfficientDet, object detection, model comparison, Vision Transformer, BiFPN, computer vision, real-time detection, efficient models, Ultralytics
 ---
 
-# RTDETRv2 vs. EfficientDet: Analyzing Real-Time Detection Architectures
+# RTDETRv2 vs EfficientDet
 
 Selecting the optimal neural network architecture is a defining choice for any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project. This comprehensive technical comparison dissects two influential object detection models: RTDETRv2, a state-of-the-art transformer-based detector, and EfficientDet, a highly scalable convolutional neural network. We will evaluate their distinct architectures, [performance metrics](https://docs.ultralytics.com/guides/yolo-performance-metrics), training methodologies, and ideal deployment scenarios to help you make data-driven decisions for your AI pipelines.
 

--- a/docs/en/compare/rtdetr-vs-efficientdet.md
+++ b/docs/en/compare/rtdetr-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs EfficientDet Comparison
 comments: true
 description: Explore RTDETRv2 vs EfficientDet for object detection with insights on architecture, performance, and use cases. Make an informed choice for your projects.
 keywords: RTDETRv2, EfficientDet, object detection, model comparison, Vision Transformer, BiFPN, computer vision, real-time detection, efficient models, Ultralytics

--- a/docs/en/compare/rtdetr-vs-pp-yoloe.md
+++ b/docs/en/compare/rtdetr-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Explore the key differences between RTDETRv2 and PP-YOLOE+, two lea
 keywords: RTDETRv2,PP-YOLOE+,object detection,model comparison,Vision Transformer,YOLO,real-time detection,AI,Ultralytics,deep learning
 ---
 
-# RTDETRv2 vs. PP-YOLOE+: A Technical Comparison of Object Detection Models
+# RTDETRv2 vs PP-YOLOE+
 
 The rapidly evolving field of computer vision has produced diverse architectural approaches to solve complex [real-time object detection](https://docs.ultralytics.com/tasks/detect) challenges. Among the most notable recent advancements are **RTDETRv2** and **PP-YOLOE+**, two powerful models that approach visual recognition from fundamentally different design philosophies. While both models aim to provide high-performance detection, their underlying mechanics, training paradigms, and ideal deployment scenarios vary significantly.
 

--- a/docs/en/compare/rtdetr-vs-pp-yoloe.md
+++ b/docs/en/compare/rtdetr-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs PP-YOLOE+ Comparison
 comments: true
 description: Explore the key differences between RTDETRv2 and PP-YOLOE+, two leading object detection models. Compare architectures, performance, and use cases.
 keywords: RTDETRv2,PP-YOLOE+,object detection,model comparison,Vision Transformer,YOLO,real-time detection,AI,Ultralytics,deep learning

--- a/docs/en/compare/rtdetr-vs-yolo11.md
+++ b/docs/en/compare/rtdetr-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Explore the technical comparison of RTDETRv2 and YOLO11. Discover s
 keywords: RTDETRv2, YOLO11, object detection, model comparison, computer vision, real-time detection, accuracy, performance metrics, Ultralytics
 ---
 
-# RTDETRv2 vs. YOLO11: A Deep Dive into Real-Time Object Detection Architectures
+# RTDETRv2 vs YOLO11
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible on edge devices and cloud servers. Two of the most prominent contenders in the current real-time object detection space are **RTDETRv2** and **YOLO11**. While both models deliver exceptional performance, they represent fundamentally different architectural philosophies: the Transformer-based approach versus the highly optimized Convolutional Neural Network (CNN).
 

--- a/docs/en/compare/rtdetr-vs-yolo11.md
+++ b/docs/en/compare/rtdetr-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLO11 Comparison
 comments: true
 description: Explore the technical comparison of RTDETRv2 and YOLO11. Discover strengths, weaknesses, and ideal use cases to choose the best detection model.
 keywords: RTDETRv2, YOLO11, object detection, model comparison, computer vision, real-time detection, accuracy, performance metrics, Ultralytics

--- a/docs/en/compare/rtdetr-vs-yolo26.md
+++ b/docs/en/compare/rtdetr-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLO26 Comparison
 comments: true
 description: Compare RTDETRv2 and YOLO26 for object detection. Explore architecture, performance, and use cases to pick the best model for your needs.
 keywords: RTDETRv2, YOLO26, object detection, model comparison, deep learning, computer vision, performance benchmark, Ultralytics

--- a/docs/en/compare/rtdetr-vs-yolo26.md
+++ b/docs/en/compare/rtdetr-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 and YOLO26 for object detection. Explore architect
 keywords: RTDETRv2, YOLO26, object detection, model comparison, deep learning, computer vision, performance benchmark, Ultralytics
 ---
 
-# RTDETRv2 vs. YOLO26: A Comprehensive Technical Comparison
+# RTDETRv2 vs YOLO26
 
 The landscape of real-time object detection has evolved dramatically, with researchers continually pushing the boundaries of speed, accuracy, and deployment efficiency. Two of the most prominent architectures currently leading this charge are the transformer-based RTDETRv2 and the state-of-the-art Convolutional Neural Network (CNN), [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26). This guide provides an in-depth analysis of their architectures, performance metrics, and ideal use cases to help you choose the right model for your next [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project.
 

--- a/docs/en/compare/rtdetr-vs-yolov10.md
+++ b/docs/en/compare/rtdetr-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv10 Comparison
 comments: true
 description: Compare RTDETRv2 and YOLOv10 for object detection. Explore their features, performance, and ideal applications to choose the best model for your project.
 keywords: RTDETRv2, YOLOv10, object detection, AI models, Vision Transformer, real-time detection, YOLO, Ultralytics, model comparison, computer vision

--- a/docs/en/compare/rtdetr-vs-yolov10.md
+++ b/docs/en/compare/rtdetr-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 and YOLOv10 for object detection. Explore their fe
 keywords: RTDETRv2, YOLOv10, object detection, AI models, Vision Transformer, real-time detection, YOLO, Ultralytics, model comparison, computer vision
 ---
 
-# RTDETRv2 vs YOLOv10: Advancements in NMS-Free Real-Time Object Detection
+# RTDETRv2 vs YOLOv10
 
 The evolution of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has been largely driven by the relentless pursuit of balancing speed and accuracy. Traditionally, real-time [object detection](https://www.ultralytics.com/glossary/object-detection) pipelines have relied on Non-Maximum Suppression (NMS) as a post-processing step to filter out overlapping bounding boxes. However, NMS introduces latency bottlenecks and complex hyperparameter tuning. Recently, two distinct architectural approaches have emerged to solve this issue natively: Transformer-based models like RTDETRv2 and CNN-based models like YOLOv10.
 

--- a/docs/en/compare/rtdetr-vs-yolov5.md
+++ b/docs/en/compare/rtdetr-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOv5 and RTDETRv2, from arch
 keywords: YOLOv5, RTDETRv2, object detection comparison, YOLOv5 vs RTDETRv2, Ultralytics models, model performance, computer vision, object detection, RTDETR, YOLOv5 features, transformer architecture
 ---
 
-# RTDETRv2 vs. YOLOv5: Evaluating Real-Time Detection Transformers and CNNs
+# RTDETRv2 vs YOLOv5
 
 The evolution of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has been largely defined by the relentless pursuit of balancing accuracy with real-time inference speed. When comparing RTDETRv2 and Ultralytics YOLOv5, developers are essentially weighing the sophisticated global context capabilities of transformer architectures against the highly optimized, battle-tested efficiency of Convolutional Neural Networks (CNNs).
 

--- a/docs/en/compare/rtdetr-vs-yolov5.md
+++ b/docs/en/compare/rtdetr-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv5 Comparison
 comments: true
 description: Discover the key differences between YOLOv5 and RTDETRv2, from architecture to accuracy, and find the best object detection model for your project.
 keywords: YOLOv5, RTDETRv2, object detection comparison, YOLOv5 vs RTDETRv2, Ultralytics models, model performance, computer vision, object detection, RTDETR, YOLOv5 features, transformer architecture

--- a/docs/en/compare/rtdetr-vs-yolov6.md
+++ b/docs/en/compare/rtdetr-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv6-3.0 Comparison
 comments: true
 description: Explore an in-depth comparison of RTDETRv2 and YOLOv6-3.0. Learn about architecture, performance, and use cases to choose the right object detection model.
 keywords: RTDETRv2, YOLOv6, object detection, model comparison, Vision Transformer, CNN, real-time AI, AI in computer vision, Ultralytics, accuracy vs speed

--- a/docs/en/compare/rtdetr-vs-yolov6.md
+++ b/docs/en/compare/rtdetr-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Explore an in-depth comparison of RTDETRv2 and YOLOv6-3.0. Learn ab
 keywords: RTDETRv2, YOLOv6, object detection, model comparison, Vision Transformer, CNN, real-time AI, AI in computer vision, Ultralytics, accuracy vs speed
 ---
 
-# RTDETRv2 vs. YOLOv6-3.0: Evaluating Real-Time Transformers Against Industrial CNNs
+# RTDETRv2 vs YOLOv6-3.0
 
 The landscape of computer vision is constantly evolving, presenting developers with a myriad of architectural choices for object detection. Two prominent models that represent divergent approaches are **RTDETRv2**, a state-of-the-art vision transformer, and **YOLOv6-3.0**, a highly optimized Convolutional Neural Network (CNN) tailored for industrial applications.
 

--- a/docs/en/compare/rtdetr-vs-yolov7.md
+++ b/docs/en/compare/rtdetr-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 and YOLOv7 for object detection. Explore their arc
 keywords: RTDETRv2, YOLOv7, object detection, model comparison, computer vision, machine learning, performance metrics, real-time detection, transformer models, YOLO
 ---
 
-# RTDETRv2 vs. YOLOv7: Navigating the Evolution of Real-Time Object Detection
+# RTDETRv2 vs YOLOv7
 
 The landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has expanded dramatically over the past few years, driven by continuous innovations in both Convolutional Neural Networks (CNNs) and Vision Transformers (ViTs). Choosing the right architecture for your deployment requires understanding the subtle trade-offs between speed, accuracy, and computational overhead. This guide explores the technical differences between two highly regarded architectures: RTDETRv2 and YOLOv7, while also highlighting the modern advancements available in the newer Ultralytics [YOLO26](https://platform.ultralytics.com/ultralytics/yolo26).
 

--- a/docs/en/compare/rtdetr-vs-yolov7.md
+++ b/docs/en/compare/rtdetr-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv7 Comparison
 comments: true
 description: Compare RTDETRv2 and YOLOv7 for object detection. Explore their architecture, performance, and use cases to choose the best model for your needs.
 keywords: RTDETRv2, YOLOv7, object detection, model comparison, computer vision, machine learning, performance metrics, real-time detection, transformer models, YOLO

--- a/docs/en/compare/rtdetr-vs-yolov8.md
+++ b/docs/en/compare/rtdetr-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv8 Comparison
 comments: true
 description: Compare RTDETRv2 and YOLOv8 for object detection. Explore architecture, performance, and use cases to select the best model for your needs.
 keywords: RTDETRv2, YOLOv8, object detection, computer vision, model comparison, deep learning, transformer architecture, real-time AI, Ultralytics

--- a/docs/en/compare/rtdetr-vs-yolov8.md
+++ b/docs/en/compare/rtdetr-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 and YOLOv8 for object detection. Explore architect
 keywords: RTDETRv2, YOLOv8, object detection, computer vision, model comparison, deep learning, transformer architecture, real-time AI, Ultralytics
 ---
 
-# RTDETRv2 vs YOLOv8: A Technical Comparison of Real-Time Vision Architectures
+# RTDETRv2 vs YOLOv8
 
 The landscape of computer vision is constantly shifting, often highlighted by the ongoing rivalry between traditional Convolutional Neural Networks (CNNs) and newer Transformer-based architectures. In this comprehensive technical comparison, we examine how **RTDETRv2**, a leading vision transformer, stacks up against **Ultralytics YOLOv8**, one of the most widely adopted and versatile CNN models in the industry. Both models offer powerful capabilities for engineers and researchers, but their underlying architectures lead to distinct differences in training methodologies, deployment constraints, and overall performance.
 

--- a/docs/en/compare/rtdetr-vs-yolov9.md
+++ b/docs/en/compare/rtdetr-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOv9 Comparison
 comments: true
 description: Compare RTDETRv2 and YOLOv9 object detection models. Explore performance, strengths, weaknesses, and ideal use cases to make an informed decision.
 keywords: RTDETRv2, YOLOv9, object detection, Ultralytics models, transformer vision, YOLO series, real-time object detection, model comparison, Vision Transformers, computer vision

--- a/docs/en/compare/rtdetr-vs-yolov9.md
+++ b/docs/en/compare/rtdetr-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 and YOLOv9 object detection models. Explore perfor
 keywords: RTDETRv2, YOLOv9, object detection, Ultralytics models, transformer vision, YOLO series, real-time object detection, model comparison, Vision Transformers, computer vision
 ---
 
-# RTDETRv2 vs. YOLOv9: Comparing Real-Time Detection Transformers and CNNs
+# RTDETRv2 vs YOLOv9
 
 The field of computer vision has witnessed a fascinating divergence in architectural philosophies, primarily between Convolutional Neural Networks (CNNs) and transformer-based models. When comparing RTDETRv2 and YOLOv9, developers are essentially evaluating the trade-offs between global attention mechanisms and programmable gradient information. Both models represent the pinnacle of their respective paradigms, pushing the boundaries of real-time object detection.
 

--- a/docs/en/compare/rtdetr-vs-yolox.md
+++ b/docs/en/compare/rtdetr-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: RTDETRv2 vs YOLOX Comparison
 comments: true
 description: Compare RTDETRv2 & YOLOX object detection models. Discover their strengths, performance, and use cases to choose the best model for your project.
 keywords: RTDETRv2,YOLOX,object detection,model comparison,Vision Transformers,real-time detection,Yolo models,Ultralytics computer vision

--- a/docs/en/compare/rtdetr-vs-yolox.md
+++ b/docs/en/compare/rtdetr-vs-yolox.md
@@ -45,7 +45,7 @@ Developed to bridge the gap between academic research and industrial application
 - **Authors:** Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, and Jian Sun
 - **Organization:** Megvii
 - **Date:** July 18, 2021
-- **Links:** [Arxiv Paper](https://arxiv.org/abs/2107.08430), [Official GitHub](https://github.com/Megvii-BaseDetection/YOLOX), [Documentation](https://yolox.readthedocs.io/en/latest/)
+- **Links:** [Arxiv Paper](https://arxiv.org/abs/2107.08430), [Official GitHub](https://github.com/Megvii-BaseDetection/YOLOX), [Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architecture and Design
 

--- a/docs/en/compare/rtdetr-vs-yolox.md
+++ b/docs/en/compare/rtdetr-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2 & YOLOX object detection models. Discover their st
 keywords: RTDETRv2,YOLOX,object detection,model comparison,Vision Transformers,real-time detection,Yolo models,Ultralytics computer vision
 ---
 
-# RTDETRv2 vs YOLOX: An In-Depth Technical Comparison of Modern Object Detectors
+# RTDETRv2 vs YOLOX
 
 The landscape of computer vision has evolved rapidly, offering developers and researchers an array of architectures to choose from when building vision-based systems. Two notable milestones in this journey are the transformer-based **RTDETRv2** and the CNN-based **YOLOX**. While both models have contributed significantly to the field of real-time object detection, they represent fundamentally different approaches to solving visual recognition problems.
 

--- a/docs/en/compare/yolo11-vs-damo-yolo.md
+++ b/docs/en/compare/yolo11-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLO11 and DAMO-YOLO. Learn about 
 keywords: YOLO11, DAMO-YOLO, object detection, model comparison, Ultralytics, performance benchmarks, machine learning, computer vision
 ---
 
-# YOLO11 vs. DAMO-YOLO: Comparing Next-Generation Object Detectors
+# YOLO11 vs DAMO-YOLO
 
 Choosing the optimal architecture is a critical step in any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project. This technical guide provides a comprehensive comparison between two powerful object detection models: [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and [DAMO-YOLO](https://github.com/tinyvision/DAMO-YOLO). We will dive into their architectural innovations, training paradigms, and real-world applicability to help you select the best tool for your deployment needs.
 

--- a/docs/en/compare/yolo11-vs-damo-yolo.md
+++ b/docs/en/compare/yolo11-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs DAMO-YOLO Comparison
 comments: true
 description: Explore a detailed comparison of YOLO11 and DAMO-YOLO. Learn about their architectures, performance metrics, and use cases for object detection.
 keywords: YOLO11, DAMO-YOLO, object detection, model comparison, Ultralytics, performance benchmarks, machine learning, computer vision

--- a/docs/en/compare/yolo11-vs-efficientdet.md
+++ b/docs/en/compare/yolo11-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLO11 and EfficientDet,
 keywords: YOLO11, EfficientDet, object detection, model comparison, YOLO vs EfficientDet, computer vision, technical comparison, Ultralytics, performance benchmarks
 ---
 
-# YOLO11 vs EfficientDet: A Comprehensive Technical Comparison
+# YOLO11 vs EfficientDet
 
 Selecting the optimal neural network for [computer vision](https://en.wikipedia.org/wiki/Computer_vision) projects requires a deep understanding of the available architectures. This guide provides an in-depth technical comparison between [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and Google's EfficientDet. We will explore their architectural differences, [performance metrics](https://docs.ultralytics.com/guides/yolo-performance-metrics), training efficiencies, and ideal deployment scenarios to help you make an informed decision for your [machine learning](https://en.wikipedia.org/wiki/Machine_learning) workloads.
 

--- a/docs/en/compare/yolo11-vs-efficientdet.md
+++ b/docs/en/compare/yolo11-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs EfficientDet Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLO11 and EfficientDet, including architecture, performance benchmarks, and ideal applications for object detection.
 keywords: YOLO11, EfficientDet, object detection, model comparison, YOLO vs EfficientDet, computer vision, technical comparison, Ultralytics, performance benchmarks

--- a/docs/en/compare/yolo11-vs-pp-yoloe.md
+++ b/docs/en/compare/yolo11-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and PP-YOLOE+ for object detection. Explore their pe
 keywords: YOLO11, PP-YOLOE+, object detection, YOLO comparison, real-time detection, AI models, computer vision, Ultralytics models, PaddlePaddle models, model performance
 ---
 
-# YOLO11 vs PP-YOLOE+: A Technical Comparison of Real-Time Detectors
+# YOLO11 vs PP-YOLOE+
 
 Selecting the optimal neural network architecture is critical when deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) applications in production. In this technical comparison, we examine two prominent models in the real-time object detection space: [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11) and Baidu's PP-YOLOE+. Both architectures offer robust performance, but they approach the challenges of accuracy, inference speed, and developer ecosystem quite differently.
 

--- a/docs/en/compare/yolo11-vs-pp-yoloe.md
+++ b/docs/en/compare/yolo11-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLO11 and PP-YOLOE+ for object detection. Explore their performance, features, and use cases to choose the best model for your needs.
 keywords: YOLO11, PP-YOLOE+, object detection, YOLO comparison, real-time detection, AI models, computer vision, Ultralytics models, PaddlePaddle models, model performance

--- a/docs/en/compare/yolo11-vs-rtdetr.md
+++ b/docs/en/compare/yolo11-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs RTDETRv2 Comparison
 comments: true
 description: Compare RTDETRv2's accuracy with YOLO11's speed in this detailed analysis of top object detection models. Decide the best fit for your projects.
 keywords: RTDETRv2, YOLO11, object detection, Ultralytics, Vision Transformer, YOLO, computer vision, real-time detection, model comparison

--- a/docs/en/compare/yolo11-vs-rtdetr.md
+++ b/docs/en/compare/yolo11-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare RTDETRv2's accuracy with YOLO11's speed in this detailed an
 keywords: RTDETRv2, YOLO11, object detection, Ultralytics, Vision Transformer, YOLO, computer vision, real-time detection, model comparison
 ---
 
-# YOLO11 vs RTDETRv2: Comparing the Evolution of CNNs and Vision Transformers
+# YOLO11 vs RTDETRv2
 
 The landscape of computer vision has expanded rapidly, offering developers a myriad of choices for building robust vision-based applications. In the realm of real-time object detection, the debate between Convolutional Neural Networks (CNNs) and Vision Transformers (ViTs) is more prominent than ever. This technical comparison delves into two leading architectures: **YOLO11**, representing the pinnacle of highly optimized CNN frameworks, and **RTDETRv2**, a powerful iteration of the Detection Transformer family.
 

--- a/docs/en/compare/yolo11-vs-yolo26.md
+++ b/docs/en/compare/yolo11-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLO26 Comparison
 comments: true
 description: Technical comparison of Ultralytics YOLO11 and YOLO26 - NMS-free, CPU-optimized YOLO26 with MuSGD. Speed, mAP, and deployment guidance for edge, cloud, and robotics.
 keywords: Ultralytics,YOLO11,YOLO26,YOLO,NMS-free,CPU-optimized,MuSGD,object detection,real-time detection,edge AI,edge deployment,Raspberry Pi,ONNX,TensorRT,mAP,small object detection,robotics

--- a/docs/en/compare/yolo11-vs-yolo26.md
+++ b/docs/en/compare/yolo11-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Technical comparison of Ultralytics YOLO11 and YOLO26 - NMS-free, C
 keywords: Ultralytics,YOLO11,YOLO26,YOLO,NMS-free,CPU-optimized,MuSGD,object detection,real-time detection,edge AI,edge deployment,Raspberry Pi,ONNX,TensorRT,mAP,small object detection,robotics
 ---
 
-# YOLO11 vs YOLO26: The Evolution of Next-Generation Vision AI
+# YOLO11 vs YOLO26
 
 The rapid evolution of computer vision continually pushes the boundaries of speed, accuracy, and deployment efficiency. In the landscape of real-time object detection, [Ultralytics](https://www.ultralytics.com) consistently sets the standard. This technical comparison explores the transition from the highly successful **YOLO11** to the cutting-edge **YOLO26**, analyzing their architectures, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/yolo11-vs-yolov10.md
+++ b/docs/en/compare/yolo11-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv10 Comparison
 comments: true
 description: Detailed technical comparison of YOLO11 and YOLOv10 for real-time object detection, covering performance, architecture, and ideal use cases.
 keywords: YOLO11, YOLOv10, Ultralytics comparison, object detection models, real-time AI, model architecture, performance benchmarks, computer vision

--- a/docs/en/compare/yolo11-vs-yolov10.md
+++ b/docs/en/compare/yolo11-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Detailed technical comparison of YOLO11 and YOLOv10 for real-time o
 keywords: YOLO11, YOLOv10, Ultralytics comparison, object detection models, real-time AI, model architecture, performance benchmarks, computer vision
 ---
 
-# YOLO11 vs YOLOv10: A Comprehensive Technical Comparison of Real-Time Object Detectors
+# YOLO11 vs YOLOv10
 
 The landscape of real-time computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible on both edge devices and cloud infrastructure. In this detailed technical analysis, we explore the nuances between two pivotal models in the domain: [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and [YOLOv10](https://docs.ultralytics.com/models/yolov10). Both represent significant leaps in [object detection](https://docs.ultralytics.com/tasks/detect) capabilities, yet they adopt fundamentally different architectural philosophies to achieve their performance.
 

--- a/docs/en/compare/yolo11-vs-yolov5.md
+++ b/docs/en/compare/yolo11-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv5 Comparison
 comments: true
 description: Explore the comprehensive comparison between YOLO11 and YOLOv5. Learn about their architectures, performance metrics, use cases, and strengths.
 keywords: YOLO11 vs YOLOv5,Yolo comparison,Yolo models,object detection,Yolo performance,Yolo benchmarks,Ultralytics,Yolo architecture

--- a/docs/en/compare/yolo11-vs-yolov5.md
+++ b/docs/en/compare/yolo11-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Explore the comprehensive comparison between YOLO11 and YOLOv5. Lea
 keywords: YOLO11 vs YOLOv5,Yolo comparison,Yolo models,object detection,Yolo performance,Yolo benchmarks,Ultralytics,Yolo architecture
 ---
 
-# YOLO11 vs YOLOv5: A Comprehensive Technical Comparison of Ultralytics Architectures
+# YOLO11 vs YOLOv5
 
 Selecting the right neural network architecture is a pivotal decision for any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) initiative. As the landscape of [artificial intelligence](https://www.ultralytics.com/glossary/artificial-intelligence-ai) evolves, so do the tools available to developers and researchers. This comprehensive guide provides an in-depth technical comparison between two landmark models from the [Ultralytics](https://www.ultralytics.com/) ecosystem: the highly celebrated YOLOv5 and the advanced YOLO11.
 

--- a/docs/en/compare/yolo11-vs-yolov6.md
+++ b/docs/en/compare/yolo11-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv6-3.0 Comparison
 comments: true
 description: Explore a detailed comparison of YOLO11 and YOLOv6-3.0, analyzing architectures, performance metrics, and use cases to choose the best object detection model.
 keywords: YOLO11, YOLOv6-3.0, object detection, model comparison, computer vision, machine learning, deep learning, performance metrics, Ultralytics, YOLO models

--- a/docs/en/compare/yolo11-vs-yolov6.md
+++ b/docs/en/compare/yolo11-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLO11 and YOLOv6-3.0, analyzing a
 keywords: YOLO11, YOLOv6-3.0, object detection, model comparison, computer vision, machine learning, deep learning, performance metrics, Ultralytics, YOLO models
 ---
 
-# YOLO11 vs YOLOv6-3.0: A Comprehensive Technical Comparison
+# YOLO11 vs YOLOv6-3.0
 
 The field of [computer vision](https://en.wikipedia.org/wiki/Computer_vision) evolves rapidly, and selecting the right model architecture is a critical decision for machine learning practitioners. Two significant milestones in the progression of real-time [object detection](https://docs.ultralytics.com/tasks/detect) are **YOLO11** and **YOLOv6-3.0**. While both models offer impressive capabilities for extracting insights from visual data, they were developed with different primary objectives and design philosophies.
 

--- a/docs/en/compare/yolo11-vs-yolov7.md
+++ b/docs/en/compare/yolo11-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv7 Comparison
 comments: true
 description: Discover the key differences between YOLO11 and YOLOv7 in object detection. Compare architectures, benchmarks, and use cases to choose the best model.
 keywords: YOLO11, YOLOv7, object detection, model comparison, YOLO benchmarks, computer vision, machine learning, Ultralytics YOLO

--- a/docs/en/compare/yolo11-vs-yolov7.md
+++ b/docs/en/compare/yolo11-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLO11 and YOLOv7 in object de
 keywords: YOLO11, YOLOv7, object detection, model comparison, YOLO benchmarks, computer vision, machine learning, Ultralytics YOLO
 ---
 
-# YOLO11 vs YOLOv7: A Detailed Technical Comparison
+# YOLO11 vs YOLOv7
 
 The landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) continues to evolve at a rapid pace, with real-time object detection remaining at the forefront of AI applications. Choosing the right architecture for your project requires navigating a complex trade-off between speed, accuracy, and ease of deployment. In this guide, we provide a comprehensive technical comparison between two prominent architectures: **Ultralytics YOLO11** and **YOLOv7**.
 

--- a/docs/en/compare/yolo11-vs-yolov8.md
+++ b/docs/en/compare/yolo11-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLO11 and YOLOv8 architectures, performance, use cases, and benchmarks. Discover which YOLO model fits your object detection needs.
 keywords: YOLO11, YOLOv8, object detection, model comparison, performance benchmarks, YOLO series, computer vision, Ultralytics YOLO, YOLO architecture

--- a/docs/en/compare/yolo11-vs-yolov8.md
+++ b/docs/en/compare/yolo11-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and YOLOv8 architectures, performance, use cases, an
 keywords: YOLO11, YOLOv8, object detection, model comparison, performance benchmarks, YOLO series, computer vision, Ultralytics YOLO, YOLO architecture
 ---
 
-# YOLO11 vs YOLOv8: A Comprehensive Technical Comparison of Real-Time Vision Models
+# YOLO11 vs YOLOv8
 
 The field of computer vision has witnessed remarkable advancements with the continuous evolution of object detection architectures. When evaluating models for real-world deployment, developers often compare the strengths of [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and its highly successful predecessor, [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8). Both models have set industry standards for speed, accuracy, and developer experience, but they cater to slightly different project lifecycles and performance thresholds.
 

--- a/docs/en/compare/yolo11-vs-yolov9.md
+++ b/docs/en/compare/yolo11-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOv9 Comparison
 comments: true
 description: Compare YOLO11 and YOLOv9 in architecture, performance, and use cases. Learn which model suits your object detection and computer vision needs.
 keywords: YOLO11, YOLOv9, model comparison, object detection, computer vision, Ultralytics, YOLO architecture, YOLO performance, real-time processing

--- a/docs/en/compare/yolo11-vs-yolov9.md
+++ b/docs/en/compare/yolo11-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and YOLOv9 in architecture, performance, and use cas
 keywords: YOLO11, YOLOv9, model comparison, object detection, computer vision, Ultralytics, YOLO architecture, YOLO performance, real-time processing
 ---
 
-# YOLO11 vs. YOLOv9: A Comprehensive Technical Comparison
+# YOLO11 vs YOLOv9
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible in real-time object detection. Two significant milestones in this journey are [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and YOLOv9. While both models offer exceptional performance, they represent different approaches to solving the core challenges of deep learning inference and training.
 

--- a/docs/en/compare/yolo11-vs-yolox.md
+++ b/docs/en/compare/yolo11-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO11 vs YOLOX Comparison
 comments: true
 description: Explore YOLO11 and YOLOX, two leading object detection models. Compare architecture, performance, and use cases to select the best model for your needs.
 keywords: YOLO11, YOLOX, object detection, machine learning, computer vision, model comparison, deep learning, Ultralytics, real-time detection, anchor-free models

--- a/docs/en/compare/yolo11-vs-yolox.md
+++ b/docs/en/compare/yolo11-vs-yolox.md
@@ -4,7 +4,7 @@ description: Explore YOLO11 and YOLOX, two leading object detection models. Comp
 keywords: YOLO11, YOLOX, object detection, machine learning, computer vision, model comparison, deep learning, Ultralytics, real-time detection, anchor-free models
 ---
 
-# YOLO11 vs YOLOX: Evolution of High-Performance Object Detection
+# YOLO11 vs YOLOX
 
 The field of computer vision has witnessed rapid advancements over the last few years, with real-time object detection models becoming increasingly sophisticated. When choosing an architecture for a production environment or academic research, developers often weigh the trade-offs between legacy milestones and cutting-edge innovations. This comprehensive comparison explores the differences between [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) and Megvii's YOLOX, providing deep insights into their architectures, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/yolo11-vs-yolox.md
+++ b/docs/en/compare/yolo11-vs-yolox.md
@@ -40,11 +40,11 @@ Developed by researchers at Megvii, **YOLOX** gained significant attention in 20
 - **Date:** 2021-07-18
 - **Arxiv:** [https://arxiv.org/abs/2107.08430](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [https://github.com/Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Docs:** [https://yolox.readthedocs.io/en/latest/](https://yolox.readthedocs.io/en/latest/)
+- **Docs:** [https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 YOLOX introduced a decoupled head and an anchor-free paradigm, which significantly reduced the number of design parameters and improved performance on academic benchmarks at the time of its release.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 !!! tip "Did You Know?"
 

--- a/docs/en/compare/yolo26-vs-damo-yolo.md
+++ b/docs/en/compare/yolo26-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs DAMO-YOLO Comparison
 comments: true
 description: Compare Ultralytics YOLO26 and DAMO-YOLO architecture, accuracy, inference speed, and edge deployment (NMS-free, MuSGD, ONNX). Choose the best real-time object detector.
 keywords: YOLO26, DAMO-YOLO, Ultralytics, object detection, real-time detection, NMS-free, MuSGD, Neural Architecture Search, NAS, edge deployment, ONNX, TensorRT, inference speed, CPU performance, model comparison, detection benchmarks, small object detection, deployment, computer vision, YOLO

--- a/docs/en/compare/yolo26-vs-damo-yolo.md
+++ b/docs/en/compare/yolo26-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 and DAMO-YOLO architecture, accuracy, in
 keywords: YOLO26, DAMO-YOLO, Ultralytics, object detection, real-time detection, NMS-free, MuSGD, Neural Architecture Search, NAS, edge deployment, ONNX, TensorRT, inference speed, CPU performance, model comparison, detection benchmarks, small object detection, deployment, computer vision, YOLO
 ---
 
-# YOLO26 vs DAMO-YOLO: A Technical Comparison of Real-Time Object Detectors
+# YOLO26 vs DAMO-YOLO
 
 When selecting a state-of-the-art computer vision model, finding the optimal balance between inference speed, accuracy, and ease of deployment is critical. This comprehensive guide compares two prominent models in the vision AI landscape: [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) and [DAMO-YOLO](https://github.com/tinyvision/DAMO-YOLO). While both architectures push the boundaries of real-time object detection, their underlying design philosophies and intended use cases differ significantly.
 

--- a/docs/en/compare/yolo26-vs-efficientdet.md
+++ b/docs/en/compare/yolo26-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs EfficientDet Comparison
 comments: true
 description: Compare Ultralytics YOLO26 vs EfficientDet architecture, mAP & latency benchmarks, NMS-free design, and best deployment use cases for edge and cloud.
 keywords: YOLO26, EfficientDet, Ultralytics, object detection, real-time detection, NMS-free, mAP, inference speed, CPU inference, edge AI, model benchmarks, TensorRT, ONNX, MuSGD, ProgLoss, small object detection, model comparison, deployment, computer vision, deep learning

--- a/docs/en/compare/yolo26-vs-efficientdet.md
+++ b/docs/en/compare/yolo26-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 vs EfficientDet architecture, mAP & late
 keywords: YOLO26, EfficientDet, Ultralytics, object detection, real-time detection, NMS-free, mAP, inference speed, CPU inference, edge AI, model benchmarks, TensorRT, ONNX, MuSGD, ProgLoss, small object detection, model comparison, deployment, computer vision, deep learning
 ---
 
-# YOLO26 vs EfficientDet: A Technical Comparison of Modern Object Detection Architectures
+# YOLO26 vs EfficientDet
 
 Choosing the right neural network architecture is critical for the success of any [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) application. This technical guide explores the trade-offs, performance metrics, and architectural innovations of two prominent models: the cutting-edge [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) and Google's well-established EfficientDet.
 

--- a/docs/en/compare/yolo26-vs-pp-yoloe.md
+++ b/docs/en/compare/yolo26-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs PP-YOLOE+ Comparison
 comments: true
 description: Detailed comparison of Ultralytics YOLO26 vs PP-YOLOE+ benchmarks, architecture, CPU/GPU inference, and deployment guidance to pick the optimal object detection model.
 keywords: YOLO26, PP-YOLOE+, Ultralytics, object detection, model comparison, benchmark, mAP, inference speed, CPU inference, GPU inference, edge AI, NMS-free, anchor-free, PaddlePaddle, TensorRT, deployment, pose estimation, segmentation, real-time detection

--- a/docs/en/compare/yolo26-vs-pp-yoloe.md
+++ b/docs/en/compare/yolo26-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Detailed comparison of Ultralytics YOLO26 vs PP-YOLOE+ benchmarks, 
 keywords: YOLO26, PP-YOLOE+, Ultralytics, object detection, model comparison, benchmark, mAP, inference speed, CPU inference, GPU inference, edge AI, NMS-free, anchor-free, PaddlePaddle, TensorRT, deployment, pose estimation, segmentation, real-time detection
 ---
 
-# YOLO26 vs PP-YOLOE+: A Technical Deep Dive into Real-Time Object Detection
+# YOLO26 vs PP-YOLOE+
 
 The field of computer vision has witnessed a rapid evolution in real-time object detection models. For ML engineers and researchers looking to deploy the most efficient vision AI models, comparing architectures like [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) and PP-YOLOE+ is critical. This comprehensive guide provides an in-depth analysis of their architectures, training methodologies, performance metrics, and ideal real-world deployment scenarios.
 

--- a/docs/en/compare/yolo26-vs-rtdetr.md
+++ b/docs/en/compare/yolo26-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 and RTDETRv2 — architecture, mAP, CPU/
 keywords: YOLO26, RTDETRv2, YOLO26 vs RTDETRv2, Ultralytics, object detection, model comparison, real-time detection, COCO benchmark, mAP, inference speed, edge deployment, NMS-free, transformer detector, CNN detector, RT-DETR
 ---
 
-# YOLO26 vs RTDETRv2: A Comprehensive Comparison of Modern Object Detection Architectures
+# YOLO26 vs RTDETRv2
 
 The landscape of computer vision is constantly evolving, presenting practitioners with a critical choice: should you leverage highly optimized Convolutional Neural Networks (CNNs) or adopt the newer Transformer-based architectures? Two prominent contenders in this arena are the cutting-edge [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) and Baidu's [RTDETRv2](https://github.com/lyuwenyu/RT-DETR/tree/main/rtdetrv2_pytorch). Both models push the boundaries of real-time object detection but rely on fundamentally different architectural philosophies.
 

--- a/docs/en/compare/yolo26-vs-rtdetr.md
+++ b/docs/en/compare/yolo26-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs RTDETRv2 Comparison
 comments: true
 description: Compare Ultralytics YOLO26 and RTDETRv2 — architecture, mAP, CPU/GPU speed, benchmarks and deployment guidance to choose the right 2026 object detector.
 keywords: YOLO26, RTDETRv2, YOLO26 vs RTDETRv2, Ultralytics, object detection, model comparison, real-time detection, COCO benchmark, mAP, inference speed, edge deployment, NMS-free, transformer detector, CNN detector, RT-DETR

--- a/docs/en/compare/yolo26-vs-yolo11.md
+++ b/docs/en/compare/yolo26-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLO11 Comparison
 comments: true
 description: Compare Ultralytics YOLO26 and YOLO11 performance, architecture, CPU inference, NMS-free design, and best-use cases to pick the right model for edge and production.
 keywords: YOLO26, YOLO11, Ultralytics, object detection, NMS-free, end-to-end detection, CPU inference, edge AI, MuSGD, ProgLoss, small object detection, model comparison, YOLO comparison, ONNX export, real-time detection

--- a/docs/en/compare/yolo26-vs-yolo11.md
+++ b/docs/en/compare/yolo26-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 and YOLO11 performance, architecture, CP
 keywords: YOLO26, YOLO11, Ultralytics, object detection, NMS-free, end-to-end detection, CPU inference, edge AI, MuSGD, ProgLoss, small object detection, model comparison, YOLO comparison, ONNX export, real-time detection
 ---
 
-# YOLO26 vs YOLO11: A Generational Leap in Vision AI
+# YOLO26 vs YOLO11
 
 When building state-of-the-art computer vision systems, selecting the right model is critical for balancing accuracy, latency, and resource efficiency. In the rapidly evolving landscape of artificial intelligence, [Ultralytics](https://www.ultralytics.com/) continues to push the boundaries of what is possible. This detailed technical comparison explores the transition from the highly successful **YOLO11** to the revolutionary new **YOLO26**, providing AI engineers and researchers with the insights needed to make informed architectural decisions.
 

--- a/docs/en/compare/yolo26-vs-yolov10.md
+++ b/docs/en/compare/yolo26-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv10 Comparison
 comments: true
 description: Technical comparison of Ultralytics YOLO26 and YOLOv10 — NMS-free end-to-end detection, CPU/edge speed, accuracy, architecture, and deployment tips.
 keywords: YOLO26, YOLOv10, Ultralytics, object detection, NMS-free, end-to-end detection, edge AI, CPU inference, model comparison, ONNX, TensorRT, deployment, instance segmentation, pose estimation, MuSGD, ProgLoss, DFL removal, benchmark, computer vision, real-time detection

--- a/docs/en/compare/yolo26-vs-yolov10.md
+++ b/docs/en/compare/yolo26-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Technical comparison of Ultralytics YOLO26 and YOLOv10 — NMS-free
 keywords: YOLO26, YOLOv10, Ultralytics, object detection, NMS-free, end-to-end detection, edge AI, CPU inference, model comparison, ONNX, TensorRT, deployment, instance segmentation, pose estimation, MuSGD, ProgLoss, DFL removal, benchmark, computer vision, real-time detection
 ---
 
-# YOLO26 vs YOLOv10: Comparing End-to-End Object Detection Models
+# YOLO26 vs YOLOv10
 
 The landscape of computer vision is constantly evolving, driven by the demand for faster, more accurate, and more efficient models. This guide provides a comprehensive technical comparison between two groundbreaking architectures in the real-time object detection space: **YOLO26** and **YOLOv10**. By analyzing their architectures, performance metrics, and deployment capabilities, we aim to help developers and researchers choose the optimal model for their vision applications.
 

--- a/docs/en/compare/yolo26-vs-yolov5.md
+++ b/docs/en/compare/yolo26-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Compare YOLO26 vs YOLOv5 architectures, benchmarks, NMS-free infere
 keywords: YOLO26, YOLOv5, object detection, real-time detection, Ultralytics, NMS-free, MuSGD, edge AI, CPU inference, benchmarks, small object detection, pose estimation, OBB, ONNX, TensorRT, model comparison
 ---
 
-# YOLO26 vs YOLOv5: A Generational Leap in Object Detection
+# YOLO26 vs YOLOv5
 
 The evolution of computer vision has been defined by the relentless pursuit of speed, accuracy, and accessibility. Choosing the right architecture is critical to the success of any AI project. In this comprehensive guide, we compare two monumental releases from Ultralytics: the pioneering [YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5) and the groundbreaking [YOLO26](https://platform.ultralytics.com/ultralytics/yolo26). While both have heavily influenced the landscape of real-time [object detection](https://en.wikipedia.org/wiki/Object_detection), their underlying technologies reflect a massive paradigm shift in how neural networks process visual data.
 

--- a/docs/en/compare/yolo26-vs-yolov5.md
+++ b/docs/en/compare/yolo26-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv5 Comparison
 comments: true
 description: Compare YOLO26 vs YOLOv5 architectures, benchmarks, NMS-free inference, MuSGD optimizer, and recommended use cases for edge, robotics, and legacy systems.
 keywords: YOLO26, YOLOv5, object detection, real-time detection, Ultralytics, NMS-free, MuSGD, edge AI, CPU inference, benchmarks, small object detection, pose estimation, OBB, ONNX, TensorRT, model comparison

--- a/docs/en/compare/yolo26-vs-yolov6.md
+++ b/docs/en/compare/yolo26-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv6-3.0 Comparison
 comments: true
 description: Compare Ultralytics YOLO26 vs YOLOv6-3.0 — architecture, NMS-free CPU speedups, mAP benchmarks, and deployment guidance for edge, mobile, and robotics.
 keywords: YOLO26, YOLOv6-3.0, Ultralytics, YOLO comparison, NMS-free, CPU inference, edge AI, mobile deployment, real-time object detection, mAP benchmarks, ONNX export, MuSGD, DFL removal, robotics

--- a/docs/en/compare/yolo26-vs-yolov6.md
+++ b/docs/en/compare/yolo26-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 vs YOLOv6-3.0 — architecture, NMS-free
 keywords: YOLO26, YOLOv6-3.0, Ultralytics, YOLO comparison, NMS-free, CPU inference, edge AI, mobile deployment, real-time object detection, mAP benchmarks, ONNX export, MuSGD, DFL removal, robotics
 ---
 
-# YOLO26 vs YOLOv6-3.0: A Comprehensive Guide to Real-Time Object Detection
+# YOLO26 vs YOLOv6-3.0
 
 The evolution of computer vision continues to accelerate, offering developers powerful new tools for [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) applications. Choosing the right architecture for deployment often dictates the success of a project. In this technical comparison, we will explore the key differences between the cutting-edge YOLO26 and the heavily industrialized YOLOv6-3.0, evaluating their architectures, training methodologies, and ideal deployment scenarios.
 

--- a/docs/en/compare/yolo26-vs-yolov7.md
+++ b/docs/en/compare/yolo26-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Compare YOLO26 vs YOLOv7 NMS-free YOLO26, CPU-optimized performance
 keywords: YOLO26, YOLOv7, Ultralytics, object detection, NMS-free, end-to-end detection, CPU optimized, edge AI, model comparison, mAP, inference speed, ONNX, TensorRT, MuSGD, deployment, YOLO26n, YOLO26l, YOLO26x, YOLOv7l, bag-of-freebies
 ---
 
-# YOLO26 vs YOLOv7: A Comprehensive Technical Comparison
+# YOLO26 vs YOLOv7
 
 The evolution of real-time object detection has seen numerous milestones, with [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) and [YOLOv7](https://github.com/WongKinYiu/yolov7) representing two significant leaps in computer vision capabilities. While YOLOv7 introduced the powerful "bag-of-freebies" methodology that redefined accuracy benchmarks in 2022, the newly released YOLO26 architecture pioneers edge-first optimizations, natively end-to-end processing, and stable training dynamics inspired by Large Language Model (LLM) innovations.
 

--- a/docs/en/compare/yolo26-vs-yolov7.md
+++ b/docs/en/compare/yolo26-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv7 Comparison
 comments: true
 description: Compare YOLO26 vs YOLOv7 NMS-free YOLO26, CPU-optimized performance, mAP & latency benchmarks, architecture differences, and deployment guidance for edge vs GPU.
 keywords: YOLO26, YOLOv7, Ultralytics, object detection, NMS-free, end-to-end detection, CPU optimized, edge AI, model comparison, mAP, inference speed, ONNX, TensorRT, MuSGD, deployment, YOLO26n, YOLO26l, YOLO26x, YOLOv7l, bag-of-freebies

--- a/docs/en/compare/yolo26-vs-yolov8.md
+++ b/docs/en/compare/yolo26-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLO26 vs YOLOv8 architecture, benchmarks (mAP, latency), t
 keywords: YOLO26, YOLOv8, YOLO comparison, object detection, NMS-free, end-to-end detection, MuSGD, ProgLoss, STAL, DFL removal, model benchmarks, mAP, inference speed, edge deployment, ONNX, TensorRT, Ultralytics, mobile AI, embedded vision
 ---
 
-# YOLO26 vs YOLOv8: Advancements in Next-Generation Object Detection
+# YOLO26 vs YOLOv8
 
 The evolution of computer vision has been defined by the pursuit of real-time performance without sacrificing accuracy. As developers and researchers navigate the landscape of modern [machine learning](https://en.wikipedia.org/wiki/Machine_learning), choosing the right model architecture is critical. This comprehensive technical comparison explores the generational leap from **[Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8)**, a wildly popular architecture that redefined the standard in 2023, to the cutting-edge **[Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26)**, released in January 2026.
 

--- a/docs/en/compare/yolo26-vs-yolov8.md
+++ b/docs/en/compare/yolo26-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLO26 vs YOLOv8 architecture, benchmarks (mAP, latency), training innovations, and deployment tips for edge, mobile, and cloud vision applications.
 keywords: YOLO26, YOLOv8, YOLO comparison, object detection, NMS-free, end-to-end detection, MuSGD, ProgLoss, STAL, DFL removal, model benchmarks, mAP, inference speed, edge deployment, ONNX, TensorRT, Ultralytics, mobile AI, embedded vision

--- a/docs/en/compare/yolo26-vs-yolov9.md
+++ b/docs/en/compare/yolo26-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLO26 vs YOLOv9 NMS-free YOLO26, MuSGD optimizer, ProgLoss
 keywords: YOLO26, YOLOv9, Ultralytics, NMS-free, MuSGD, ProgLoss, STAL, edge inference, CPU acceleration, real-time object detection, ONNX, TensorRT, benchmarks, deployment, Raspberry Pi, model comparison
 ---
 
-# YOLO26 vs YOLOv9: The Next Evolution in Real-Time Object Detection
+# YOLO26 vs YOLOv9
 
 The landscape of computer vision advances rapidly, with new architectures continuously pushing the boundaries of speed and accuracy. In this technical comparison, we examine the differences between **YOLO26** and **YOLOv9**, two highly influential models in the domain of real-time object detection. While both models offer distinct architectural innovations, understanding their performance trade-offs, deployment capabilities, and hardware requirements is crucial for selecting the right tool for your next vision project.
 

--- a/docs/en/compare/yolo26-vs-yolov9.md
+++ b/docs/en/compare/yolo26-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOv9 Comparison
 comments: true
 description: Compare YOLO26 vs YOLOv9 NMS-free YOLO26, MuSGD optimizer, ProgLoss/STAL, CPU & edge performance, accuracy benchmarks and deployment tips.
 keywords: YOLO26, YOLOv9, Ultralytics, NMS-free, MuSGD, ProgLoss, STAL, edge inference, CPU acceleration, real-time object detection, ONNX, TensorRT, benchmarks, deployment, Raspberry Pi, model comparison

--- a/docs/en/compare/yolo26-vs-yolox.md
+++ b/docs/en/compare/yolo26-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 vs YOLOX Comparison
 comments: true
 description: Compare Ultralytics YOLO26 and YOLOX benchmarks, NMS-free architecture, MuSGD optimizer, CPU/TensorRT speeds, and edge deployment for real-time object detection.
 keywords: YOLO26, YOLOX, Ultralytics, object detection, real-time detection, edge AI, NMS-free, end-to-end detection, MuSGD, inference latency, ONNX, TensorRT, model benchmark, deployment, small object detection, robotics, drone navigation, smart retail, model comparison, export

--- a/docs/en/compare/yolo26-vs-yolox.md
+++ b/docs/en/compare/yolo26-vs-yolox.md
@@ -36,9 +36,9 @@ Understanding the origins and core philosophies of these models is essential for
 - **Date:** 2021-07-18
 - **Arxiv:** [YOLOX Technical Report](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [YOLOX GitHub Repository](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Docs:** [YOLOX Documentation](https://yolox.readthedocs.io/en/latest/)
+- **Docs:** [YOLOX Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 **YOLOX** was a major step forward, introducing a decoupled head and an anchor-free architecture alongside the SimOTA label assignment strategy. It offered an excellent balance of speed and accuracy at the time of its release, making it a popular choice for many legacy systems.
 

--- a/docs/en/compare/yolo26-vs-yolox.md
+++ b/docs/en/compare/yolo26-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLO26 and YOLOX benchmarks, NMS-free architect
 keywords: YOLO26, YOLOX, Ultralytics, object detection, real-time detection, edge AI, NMS-free, end-to-end detection, MuSGD, inference latency, ONNX, TensorRT, model benchmark, deployment, small object detection, robotics, drone navigation, smart retail, model comparison, export
 ---
 
-# YOLO26 vs YOLOX: A New Era of Anchor-Free Object Detection
+# YOLO26 vs YOLOX
 
 The evolution of computer vision has been marked by significant architectural leaps. In 2021, YOLOX introduced a highly influential anchor-free paradigm that bridged the gap between academic research and industrial application. Fast forward to 2026, and the landscape has been redefined by [Ultralytics YOLO](https://www.ultralytics.com/yolo), specifically with the release of YOLO26. This comprehensive comparison explores how YOLO26 builds upon historical innovations to deliver unmatched performance, versatility, and ease of use.
 

--- a/docs/en/compare/yolov10-vs-damo-yolo.md
+++ b/docs/en/compare/yolov10-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Discover the key differences, performance benchmarks, and use cases
 keywords: YOLOv10, DAMO-YOLO, object detection, YOLO comparison, computer vision, model benchmarking, NMS-free training, neural architecture search, RepGFPN, real-time detection, Ultralytics
 ---
 
-# YOLOv10 vs DAMO-YOLO: A Technical Comparison of Real-Time Object Detectors
+# YOLOv10 vs DAMO-YOLO
 
 When building modern [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipelines, selecting the right real-time object detection architecture is critical. In this comprehensive technical analysis, we explore the architectures, performance metrics, and ideal use cases for **YOLOv10** and **DAMO-YOLO**. Both models represent significant leaps in object detection capabilities, but they take different architectural paths to achieve their goals.
 

--- a/docs/en/compare/yolov10-vs-damo-yolo.md
+++ b/docs/en/compare/yolov10-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs DAMO-YOLO Comparison
 comments: true
 description: Discover the key differences, performance benchmarks, and use cases of YOLOv10 and DAMO-YOLO in this detailed technical comparison.
 keywords: YOLOv10, DAMO-YOLO, object detection, YOLO comparison, computer vision, model benchmarking, NMS-free training, neural architecture search, RepGFPN, real-time detection, Ultralytics

--- a/docs/en/compare/yolov10-vs-efficientdet.md
+++ b/docs/en/compare/yolov10-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs EfficientDet Comparison
 comments: true
 description: Compare YOLOv10 and EfficientDet for object detection. Explore performance, use cases, and strengths to choose the best model for your needs.
 keywords: YOLOv10, EfficientDet, object detection, model comparison, real-time detection, computer vision, edge devices, accuracy, performance metrics

--- a/docs/en/compare/yolov10-vs-efficientdet.md
+++ b/docs/en/compare/yolov10-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and EfficientDet for object detection. Explore perf
 keywords: YOLOv10, EfficientDet, object detection, model comparison, real-time detection, computer vision, edge devices, accuracy, performance metrics
 ---
 
-# YOLOv10 vs EfficientDet: Comparing Real-Time Object Detection Architectures
+# YOLOv10 vs EfficientDet
 
 Selecting the optimal neural network for [object detection](https://docs.ultralytics.com/tasks/detect) is a critical decision that dictates the success of modern computer vision systems. Two prominent architectures that have significantly influenced the field are **YOLOv10** and **EfficientDet**. While both aim to maximize accuracy while minimizing computational overhead, they take vastly different architectural approaches to achieve these goals.
 

--- a/docs/en/compare/yolov10-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov10-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs PP-YOLOE+ Comparison
 comments: true
 description: Discover the key differences between YOLOv10 and PP-YOLOE+ with performance benchmarks, architecture insights, and ideal use cases for your projects.
 keywords: YOLOv10,PP-YOLOE+,object detection,model comparison,computer vision,Ultralytics,YOLO models,PaddlePaddle,performance benchmark

--- a/docs/en/compare/yolov10-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov10-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOv10 and PP-YOLOE+ with per
 keywords: YOLOv10,PP-YOLOE+,object detection,model comparison,computer vision,Ultralytics,YOLO models,PaddlePaddle,performance benchmark
 ---
 
-# YOLOv10 vs PP-YOLOE+: A Comprehensive Technical Comparison
+# YOLOv10 vs PP-YOLOE+
 
 In the rapidly evolving landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv), choosing the optimal architecture for real-time object detection is crucial for balancing accuracy, inference speed, and deployment efficiency. Two notable contenders in this arena are **YOLOv10** and **PP-YOLOE+**. While both models offer robust capabilities, they originate from different design philosophies and ecosystem integrations.
 

--- a/docs/en/compare/yolov10-vs-rtdetr.md
+++ b/docs/en/compare/yolov10-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs RTDETRv2 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv10 and RTDETRv2. Discover their strengths, weaknesses, performance metrics, and ideal applications for object detection.
 keywords: YOLOv10,RTDETRv2,object detection,model comparison,AI,computer vision,Ultralytics,real-time detection,transformer-based models,YOLO series

--- a/docs/en/compare/yolov10-vs-rtdetr.md
+++ b/docs/en/compare/yolov10-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv10 and RTDETRv2. Discover the
 keywords: YOLOv10,RTDETRv2,object detection,model comparison,AI,computer vision,Ultralytics,real-time detection,transformer-based models,YOLO series
 ---
 
-# YOLOv10 vs. RTDETRv2: Evaluating Real-Time End-to-End Object Detectors
+# YOLOv10 vs RTDETRv2
 
 The landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) moves at a blistering pace, with new architectures constantly redefining the state of the art in real-time object detection. Two significant milestones in this evolution are YOLOv10 and RTDETRv2. Both models aim to solve a fundamental bottleneck in traditional detection pipelines by eliminating the need for Non-Maximum Suppression (NMS) post-processing, yet they approach this challenge from entirely different architectural paradigms.
 

--- a/docs/en/compare/yolov10-vs-yolo11.md
+++ b/docs/en/compare/yolov10-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv10 and YOLO11, two advanced o
 keywords: YOLOv10, YOLO11, object detection, model comparison, computer vision, real-time detection, NMS-free training, Ultralytics models, edge computing, accuracy vs speed
 ---
 
-# YOLOv10 vs YOLO11: A Deep Dive into Real-Time Object Detection Architectures
+# YOLOv10 vs YOLO11
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible in real-time processing. For developers and researchers navigating this fast-paced field, understanding the nuances between cutting-edge models is crucial. This detailed comparison explores the technical differences, performance trade-offs, and ideal use cases for [YOLOv10](https://arxiv.org/abs/2405.14458) and [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11), two highly capable object detection frameworks.
 

--- a/docs/en/compare/yolov10-vs-yolo11.md
+++ b/docs/en/compare/yolov10-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLO11 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv10 and YOLO11, two advanced object detection models. Understand their performance, strengths, and ideal use cases.
 keywords: YOLOv10, YOLO11, object detection, model comparison, computer vision, real-time detection, NMS-free training, Ultralytics models, edge computing, accuracy vs speed

--- a/docs/en/compare/yolov10-vs-yolo26.md
+++ b/docs/en/compare/yolov10-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLOv10 and YOLO26, incl
 keywords: YOLOv10, YOLO26, object detection, model comparison, YOLOv10 vs YOLO26, computer vision, technical comparison, Ultralytics, performance benchmarks
 ---
 
-# YOLOv10 vs YOLO26: The Evolution of End-to-End Object Detection
+# YOLOv10 vs YOLO26
 
 The landscape of computer vision has witnessed remarkable advancements in recent years, shifting from complex, post-processing-heavy architectures to streamlined, end-to-end models. This technical comparison delves into two major milestones in this journey: the academic breakthrough of YOLOv10 and the cutting-edge, enterprise-ready YOLO26. By examining their architectures, training methodologies, and real-world deployment capabilities, developers can make informed decisions when building their next vision AI application.
 

--- a/docs/en/compare/yolov10-vs-yolo26.md
+++ b/docs/en/compare/yolov10-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLO26 Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLOv10 and YOLO26, including architecture, performance benchmarks, and ideal applications for object detection.
 keywords: YOLOv10, YOLO26, object detection, model comparison, YOLOv10 vs YOLO26, computer vision, technical comparison, Ultralytics, performance benchmarks

--- a/docs/en/compare/yolov10-vs-yolov5.md
+++ b/docs/en/compare/yolov10-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOv5 models for object detection. Explore key
 keywords: YOLOv10, YOLOv5, object detection, real-time models, computer vision, NMS-free, model comparison, YOLO, Ultralytics, machine learning
 ---
 
-# YOLOv10 vs YOLOv5: A Comprehensive Technical Comparison
+# YOLOv10 vs YOLOv5
 
 Choosing the right neural network architecture is critical for deploying successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipelines in production. This page provides an in-depth technical analysis comparing **YOLOv10** and **YOLOv5**, two highly influential models in the evolution of real-time object detection. While both models have made significant impacts on the AI community, they represent different eras and philosophies in deep learning architecture design.
 

--- a/docs/en/compare/yolov10-vs-yolov5.md
+++ b/docs/en/compare/yolov10-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOv5 Comparison
 comments: true
 description: Compare YOLOv10 and YOLOv5 models for object detection. Explore key features, performance metrics, strengths, and use cases to choose the right model.
 keywords: YOLOv10, YOLOv5, object detection, real-time models, computer vision, NMS-free, model comparison, YOLO, Ultralytics, machine learning

--- a/docs/en/compare/yolov10-vs-yolov6.md
+++ b/docs/en/compare/yolov10-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOv6-3.0 Comparison
 comments: true
 description: Discover the key differences between YOLOv10 and YOLOv6-3.0, including architecture, performance benchmarks, and ideal use cases for object detection.
 keywords: YOLOv10, YOLOv6, YOLO comparison, object detection models, computer vision, deep learning, benchmark, NMS-free, model architecture, Ultralytics

--- a/docs/en/compare/yolov10-vs-yolov6.md
+++ b/docs/en/compare/yolov10-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOv10 and YOLOv6-3.0, includ
 keywords: YOLOv10, YOLOv6, YOLO comparison, object detection models, computer vision, deep learning, benchmark, NMS-free, model architecture, Ultralytics
 ---
 
-# YOLOv10 vs. YOLOv6-3.0: A Comprehensive Technical Comparison
+# YOLOv10 vs YOLOv6-3.0
 
 In the rapidly evolving landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv), selecting the optimal [object detection](https://docs.ultralytics.com/tasks/detect) architecture is crucial for balancing inference speed, model accuracy, and deployment feasibility. This guide provides an in-depth, technical comparison between two formidable models: the academic powerhouse **YOLOv10** and the industrially focused **YOLOv6-3.0**. Both bring unique architectural innovations to the table, solving distinct challenges in the deployment of real-time vision systems.
 

--- a/docs/en/compare/yolov10-vs-yolov7.md
+++ b/docs/en/compare/yolov10-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOv7 Comparison
 comments: true
 description: Compare YOLOv10 and YOLOv7 object detection models. Analyze performance, architecture, and use cases to choose the best fit for your AI project.
 keywords: YOLOv10, YOLOv7, object detection, model comparison, AI, deep learning, computer vision, performance metrics, architecture, edge AI, robotics, autonomous systems

--- a/docs/en/compare/yolov10-vs-yolov7.md
+++ b/docs/en/compare/yolov10-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOv7 object detection models. Analyze perform
 keywords: YOLOv10, YOLOv7, object detection, model comparison, AI, deep learning, computer vision, performance metrics, architecture, edge AI, robotics, autonomous systems
 ---
 
-# YOLOv10 vs YOLOv7: The Evolution of Real-Time Object Detection
+# YOLOv10 vs YOLOv7
 
 The rapid progression of computer vision over the last few years has yielded increasingly efficient architectures for real-time applications. Comparing [YOLOv10](https://docs.ultralytics.com/models/yolov10) and [YOLOv7](https://docs.ultralytics.com/models/yolov7) highlights a crucial transition period in this evolution. While YOLOv7 introduced highly effective training strategies and architectural scaling, YOLOv10 revolutionized deployment by eliminating the longstanding reliance on Non-Maximum Suppression (NMS).
 

--- a/docs/en/compare/yolov10-vs-yolov8.md
+++ b/docs/en/compare/yolov10-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOv8 for object detection. Discover differenc
 keywords: YOLOv10, YOLOv8, object detection, model comparison, computer vision, real-time detection, deep learning, AI efficiency, YOLO models
 ---
 
-# YOLOv10 vs YOLOv8: A Technical Deep Dive into Modern Object Detection
+# YOLOv10 vs YOLOv8
 
 The evolution of real-time object detection has seen a rapid succession of groundbreaking architectures, each attempting to push the boundaries of accuracy, inference speed, and computational efficiency. In this comprehensive technical guide, we compare two major milestones in the computer vision landscape: **YOLOv10** and **[Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8)**. While YOLOv8 established a highly versatile and production-ready standard, YOLOv10 introduced architectural shifts specifically aimed at removing post-processing bottlenecks.
 

--- a/docs/en/compare/yolov10-vs-yolov8.md
+++ b/docs/en/compare/yolov10-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLOv10 and YOLOv8 for object detection. Discover differences in performance, architecture, and real-world applications to choose the best model.
 keywords: YOLOv10, YOLOv8, object detection, model comparison, computer vision, real-time detection, deep learning, AI efficiency, YOLO models

--- a/docs/en/compare/yolov10-vs-yolov9.md
+++ b/docs/en/compare/yolov10-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOv9 Comparison
 comments: true
 description: Compare YOLOv10 and YOLOv9 object detection models. Explore architectures, metrics, and use cases to choose the best model for your application.
 keywords: YOLOv10,YOLOv9,Ultralytics,object detection,real-time AI,computer vision,model comparison,AI deployment,deep learning

--- a/docs/en/compare/yolov10-vs-yolov9.md
+++ b/docs/en/compare/yolov10-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOv9 object detection models. Explore archite
 keywords: YOLOv10,YOLOv9,Ultralytics,object detection,real-time AI,computer vision,model comparison,AI deployment,deep learning
 ---
 
-# YOLOv10 vs. YOLOv9: A Technical Deep Dive into Modern Object Detection
+# YOLOv10 vs YOLOv9
 
 The evolution of real-time computer vision has been marked by continuous breakthroughs in speed, accuracy, and architectural efficiency. When evaluating modern solutions for your next deployment, comparing **YOLOv10** and **YOLOv9** offers a fascinating look at two distinct approaches to solving deep learning bottlenecks. While YOLOv9 focuses on maximizing gradient information flow during training, YOLOv10 pioneers a native end-to-end design that completely eliminates traditional post-processing hurdles.
 

--- a/docs/en/compare/yolov10-vs-yolox.md
+++ b/docs/en/compare/yolov10-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10 vs YOLOX Comparison
 comments: true
 description: Compare YOLOv10 and YOLOX for object detection. Explore performance metrics, architecture, strengths, and ideal use cases for these top AI models.
 keywords: YOLOv10, YOLOX, object detection, YOLO comparison, real-time AI models, Ultralytics, computer vision, model performance, anchor-free detection, AI benchmark

--- a/docs/en/compare/yolov10-vs-yolox.md
+++ b/docs/en/compare/yolov10-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOX for object detection. Explore performance
 keywords: YOLOv10, YOLOX, object detection, YOLO comparison, real-time AI models, Ultralytics, computer vision, model performance, anchor-free detection, AI benchmark
 ---
 
-# YOLOv10 vs YOLOX: Evolution of Anchor-Free and NMS-Free Object Detection
+# YOLOv10 vs YOLOX
 
 The field of computer vision is driven by rapid advancements in real-time object detection architectures. This detailed technical comparison explores two influential models that pushed the boundaries of efficiency and design paradigms: **YOLOv10** and **YOLOX**. By examining their architectural differences, performance metrics, and training methodologies, developers and researchers can make informed decisions for deploying robust vision systems.
 

--- a/docs/en/compare/yolov10-vs-yolox.md
+++ b/docs/en/compare/yolov10-vs-yolox.md
@@ -39,7 +39,7 @@ YOLOX emerged as an anchor-free version of the traditional YOLO design, offering
 - **Date:** July 18, 2021
 - **ArXiv:** [2107.08430](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Docs:** [YOLOX Official Documentation](https://yolox.readthedocs.io/en/latest/)
+- **Docs:** [YOLOX Official Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 [Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX){ .md-button }
 

--- a/docs/en/compare/yolov5-vs-damo-yolo.md
+++ b/docs/en/compare/yolov5-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs DAMO-YOLO Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv5 and DAMO-YOLO, including architecture, accuracy, speed, and use cases for optimal object detection solutions.
 keywords: YOLOv5, DAMO-YOLO, object detection, computer vision, Ultralytics, model comparison, AI, real-time AI, deep learning

--- a/docs/en/compare/yolov5-vs-damo-yolo.md
+++ b/docs/en/compare/yolov5-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv5 and DAMO-YOLO, including ar
 keywords: YOLOv5, DAMO-YOLO, object detection, computer vision, Ultralytics, model comparison, AI, real-time AI, deep learning
 ---
 
-# YOLOv5 vs. DAMO-YOLO: A Comprehensive Technical Comparison
+# YOLOv5 vs DAMO-YOLO
 
 The landscape of real-time [computer vision](https://en.wikipedia.org/wiki/Computer_vision) is continuously evolving, with researchers and engineers striving for the perfect balance of accuracy, speed, and usability. Two prominent models that have shaped this journey are **Ultralytics YOLOv5** and Alibaba's **DAMO-YOLO**.
 

--- a/docs/en/compare/yolov5-vs-efficientdet.md
+++ b/docs/en/compare/yolov5-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs EfficientDet Comparison
 comments: true
 description: Compare YOLOv5 and EfficientDet for object detection. Explore architecture, performance, strengths, and use cases to choose the right model.
 keywords: YOLOv5, EfficientDet, object detection, model comparison, computer vision, performance metrics, Ultralytics, real-time detection, deep learning

--- a/docs/en/compare/yolov5-vs-efficientdet.md
+++ b/docs/en/compare/yolov5-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and EfficientDet for object detection. Explore archi
 keywords: YOLOv5, EfficientDet, object detection, model comparison, computer vision, performance metrics, Ultralytics, real-time detection, deep learning
 ---
 
-# YOLOv5 vs. EfficientDet: Evaluating Real-Time Object Detection Architectures
+# YOLOv5 vs EfficientDet
 
 When embarking on a new [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project, choosing the right neural network architecture is one of the most consequential decisions you will make. This guide provides an in-depth technical comparison between **Ultralytics YOLOv5** and Google's **EfficientDet**. By analyzing their architectures, performance metrics, and training ecosystems, we aim to help developers and researchers identify the best [object detection](https://docs.ultralytics.com/tasks/detect) model for their specific deployment environments.
 

--- a/docs/en/compare/yolov5-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov5-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and PP-YOLOE+ object detection models. Explore their
 keywords: YOLOv5, PP-YOLOE+, object detection, computer vision, machine learning, model comparison, YOLO models, PaddlePaddle, AI, technical comparison
 ---
 
-# YOLOv5 vs. PP-YOLOE+: A Technical Deep Dive into Modern Object Detection
+# YOLOv5 vs PP-YOLOE+
 
 Choosing the right neural network architecture is essential for any modern computer vision project. When developers and researchers evaluate models for real-time object detection, the decision often comes down to balancing accuracy, inference speed, and deployment ease. This technical comparison examines **YOLOv5** and **PP-YOLOE+**, exploring their architectures, performance metrics, and training methodologies to help you select the optimal solution for your application.
 

--- a/docs/en/compare/yolov5-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov5-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLOv5 and PP-YOLOE+ object detection models. Explore their architecture, performance, and use cases to choose the best fit for your project.
 keywords: YOLOv5, PP-YOLOE+, object detection, computer vision, machine learning, model comparison, YOLO models, PaddlePaddle, AI, technical comparison

--- a/docs/en/compare/yolov5-vs-rtdetr.md
+++ b/docs/en/compare/yolov5-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs RTDETRv2 Comparison
 comments: true
 description: Compare YOLOv5 and RTDETRv2 for object detection. Explore their architectures, performance metrics, strengths, and best use cases in computer vision.
 keywords: YOLOv5, RTDETRv2, object detection, model comparison, Ultralytics, computer vision, machine learning, real-time detection, Vision Transformers, AI models

--- a/docs/en/compare/yolov5-vs-rtdetr.md
+++ b/docs/en/compare/yolov5-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and RTDETRv2 for object detection. Explore their arc
 keywords: YOLOv5, RTDETRv2, object detection, model comparison, Ultralytics, computer vision, machine learning, real-time detection, Vision Transformers, AI models
 ---
 
-# YOLOv5 vs RTDETRv2: Evaluating CNN vs. Transformer Architectures for Object Detection
+# YOLOv5 vs RTDETRv2
 
 The landscape of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has expanded significantly over the past few years, offering developers a wide array of architectures to tackle complex visual tasks. Among the most popular paradigms are Convolutional Neural Networks (CNNs) and Detection Transformers (DETRs).
 

--- a/docs/en/compare/yolov5-vs-yolo11.md
+++ b/docs/en/compare/yolov5-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Explore the ultimate comparison between YOLOv5 and YOLO11. Learn ab
 keywords: YOLOv5, YOLO11, object detection, Ultralytics, YOLO comparison, performance metrics, computer vision, real-time detection, model architecture
 ---
 
-# YOLOv5 vs YOLO11: A Comprehensive Technical Comparison
+# YOLOv5 vs YOLO11
 
 When choosing the right computer vision architecture for a new project, understanding the evolution of state-of-the-art models is crucial. The progression from earlier architectures to modern unified frameworks highlights significant leaps in both algorithmic efficiency and developer experience. This guide provides an in-depth technical comparison between two landmark models developed by Ultralytics: the pioneering YOLOv5 and the highly refined YOLO11.
 

--- a/docs/en/compare/yolov5-vs-yolo11.md
+++ b/docs/en/compare/yolov5-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLO11 Comparison
 comments: true
 description: Explore the ultimate comparison between YOLOv5 and YOLO11. Learn about their architecture, performance metrics, and ideal use cases for object detection.
 keywords: YOLOv5, YOLO11, object detection, Ultralytics, YOLO comparison, performance metrics, computer vision, real-time detection, model architecture

--- a/docs/en/compare/yolov5-vs-yolo26.md
+++ b/docs/en/compare/yolov5-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLO26 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv5 and YOLO26 including benchmarks, architectures, and applications for optimal object detection model choice.
 keywords: YOLOv5, YOLO26, object detection, model comparison, YOLOv5, YOLO26, computer vision, benchmarks, architecture, real-time detection

--- a/docs/en/compare/yolov5-vs-yolo26.md
+++ b/docs/en/compare/yolov5-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv5 and YOLO26 including benchm
 keywords: YOLOv5, YOLO26, object detection, model comparison, YOLOv5, YOLO26, computer vision, benchmarks, architecture, real-time detection
 ---
 
-# YOLOv5 vs YOLO26: A Generational Leap in Real-Time Object Detection
+# YOLOv5 vs YOLO26
 
 The evolution of computer vision has been defined by the continuous push for faster, more accurate, and more accessible models. When comparing [Ultralytics YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5) to the cutting-edge [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26), we are looking at a paradigm shift that bridges the gap between robust legacy systems and the bleeding edge of modern AI deployment.
 

--- a/docs/en/compare/yolov5-vs-yolov10.md
+++ b/docs/en/compare/yolov5-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOv10 Comparison
 comments: true
 description: Explore a detailed YOLOv5 vs YOLOv10 comparison, analyzing architectures, performance, and ideal applications for cutting-edge object detection.
 keywords: YOLOv5, YOLOv10, object detection, Ultralytics, machine learning models, real-time detection, AI models comparison, computer vision

--- a/docs/en/compare/yolov5-vs-yolov10.md
+++ b/docs/en/compare/yolov5-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Explore a detailed YOLOv5 vs YOLOv10 comparison, analyzing architec
 keywords: YOLOv5, YOLOv10, object detection, Ultralytics, machine learning models, real-time detection, AI models comparison, computer vision
 ---
 
-# YOLOv5 vs. YOLOv10: A Comprehensive Technical Comparison
+# YOLOv5 vs YOLOv10
 
 The field of real-time computer vision has seen exponential growth over the past few years, with various architectures pushing the boundaries of what is possible on modern hardware. When evaluating state-of-the-art architectures, the comparison between [YOLOv5](https://docs.ultralytics.com/models/yolov5) and [YOLOv10](https://docs.ultralytics.com/models/yolov10) highlights a significant evolutionary step in the domain of object detection. This technical deep dive explores their architectural paradigms, performance trade-offs, and how developers can leverage these tools in production environments.
 

--- a/docs/en/compare/yolov5-vs-yolov6.md
+++ b/docs/en/compare/yolov5-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOv6-3.0 Comparison
 comments: true
 description: Compare YOLOv5 and YOLOv6-3.0 object detection models. Explore their architecture, performance, and applications to choose the best fit for your needs.
 keywords: YOLOv5, YOLOv6-3.0, object detection, model comparison, computer vision, Ultralytics, Meituan, YOLO series, performance benchmarks, real-time detection

--- a/docs/en/compare/yolov5-vs-yolov6.md
+++ b/docs/en/compare/yolov5-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and YOLOv6-3.0 object detection models. Explore thei
 keywords: YOLOv5, YOLOv6-3.0, object detection, model comparison, computer vision, Ultralytics, Meituan, YOLO series, performance benchmarks, real-time detection
 ---
 
-# YOLOv5 vs. YOLOv6-3.0: A Comprehensive Guide to Real-Time Object Detection Models
+# YOLOv5 vs YOLOv6-3.0
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of speed and accuracy. When selecting a model for your next vision AI project, developers often find themselves comparing established, versatile frameworks with highly specialized industrial detectors. This deep dive explores the technical nuances between **Ultralytics YOLOv5** and **Meituan's YOLOv6-3.0**, helping you choose the best tool for your deployment needs.
 

--- a/docs/en/compare/yolov5-vs-yolov7.md
+++ b/docs/en/compare/yolov5-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOv7 Comparison
 comments: true
 description: Discover the technical comparison between YOLOv5 and YOLOv7, covering architectures, benchmarks, strengths, and ideal use cases for object detection.
 keywords: YOLOv5, YOLOv7, object detection, model comparison, AI, deep learning, computer vision, benchmarks, accuracy, inference speed, Ultralytics

--- a/docs/en/compare/yolov5-vs-yolov7.md
+++ b/docs/en/compare/yolov5-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Discover the technical comparison between YOLOv5 and YOLOv7, coveri
 keywords: YOLOv5, YOLOv7, object detection, model comparison, AI, deep learning, computer vision, benchmarks, accuracy, inference speed, Ultralytics
 ---
 
-# The Evolution of Object Detection: YOLOv5 vs. YOLOv7
+# YOLOv5 vs YOLOv7
 
 The landscape of computer vision has evolved rapidly over the last few years, driven by the need for faster, more accurate real-time object detection. When choosing the right architecture for your computer vision project, understanding the nuances between popular models like [Ultralytics YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5) and YOLOv7 is crucial. This comprehensive technical comparison delves into their architectures, training methodologies, performance metrics, and ideal deployment scenarios to help you make an informed decision.
 

--- a/docs/en/compare/yolov5-vs-yolov8.md
+++ b/docs/en/compare/yolov5-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLOv5 and YOLOv8 for speed, accuracy, and versatility. Learn which Ultralytics model is best for your object detection and vision tasks.
 keywords: YOLOv5, YOLOv8, Ultralytics, object detection, computer vision, YOLO models, model comparison, AI, machine learning, deep learning

--- a/docs/en/compare/yolov5-vs-yolov8.md
+++ b/docs/en/compare/yolov5-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and YOLOv8 for speed, accuracy, and versatility. Lea
 keywords: YOLOv5, YOLOv8, Ultralytics, object detection, computer vision, YOLO models, model comparison, AI, machine learning, deep learning
 ---
 
-# YOLOv5 vs. YOLOv8: Evaluating the Evolution of Ultralytics Vision AI
+# YOLOv5 vs YOLOv8
 
 When building scalable and efficient [computer vision](https://en.wikipedia.org/wiki/Computer_vision) applications, selecting the right architecture is critical. The evolution of the [Ultralytics](https://www.ultralytics.com/) ecosystem has consistently pushed the boundaries of speed and accuracy, providing developers with robust tools for real-world deployments. This technical comparison delves into the differences between **YOLOv5** and **YOLOv8**, exploring their architectures, performance trade-offs, and ideal use cases to help you make an informed decision for your next AI project.
 

--- a/docs/en/compare/yolov5-vs-yolov9.md
+++ b/docs/en/compare/yolov5-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and YOLOv9 - performance, architecture, and use case
 keywords: YOLOv5, YOLOv9, object detection, model comparison, performance metrics, real-time detection, computer vision, Ultralytics, machine learning
 ---
 
-# YOLOv5 vs. YOLOv9: An In-Depth Technical Comparison
+# YOLOv5 vs YOLOv9
 
 The landscape of computer vision and real-time object detection has seen remarkable advancements over the past few years. Navigating the choice between established, battle-tested models and newer research architectures is a common challenge for machine learning engineers. This guide provides a comprehensive technical comparison between two highly influential models in the YOLO family: **YOLOv5** and **YOLOv9**.
 

--- a/docs/en/compare/yolov5-vs-yolov9.md
+++ b/docs/en/compare/yolov5-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOv9 Comparison
 comments: true
 description: Compare YOLOv5 and YOLOv9 - performance, architecture, and use cases. Find the best model for real-time object detection and computer vision tasks.
 keywords: YOLOv5, YOLOv9, object detection, model comparison, performance metrics, real-time detection, computer vision, Ultralytics, machine learning

--- a/docs/en/compare/yolov5-vs-yolox.md
+++ b/docs/en/compare/yolov5-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and YOLOX object detection models. Explore performan
 keywords: YOLOv5, YOLOX, object detection, model comparison, computer vision, Ultralytics, anchor-based, anchor-free, real-time detection, AI models
 ---
 
-# YOLOv5 vs YOLOX: A Comprehensive Technical Comparison
+# YOLOv5 vs YOLOX
 
 The evolution of real-time computer vision has seen numerous milestones, with different architectures pushing the boundaries of speed and accuracy. Two highly influential models in this space are **YOLOv5** and **YOLOX**. While both are renowned for their high performance in object detection, they take fundamentally different architectural approaches.
 

--- a/docs/en/compare/yolov5-vs-yolox.md
+++ b/docs/en/compare/yolov5-vs-yolox.md
@@ -42,7 +42,7 @@ One of the greatest strengths of YOLOv5 is its well-maintained ecosystem. It boa
 - **Date:** 2021-07-18
 - **Arxiv:** [YOLOX: Exceeding YOLO Series in 2021](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [Megvii YOLOX Repository](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Documentation:** [YOLOX ReadTheDocs](https://yolox.readthedocs.io/en/latest/)
+- **Documentation:** [YOLOX GitHub Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 Developed by researchers at Megvii, YOLOX took a different path by introducing an anchor-free design to the YOLO family. By eliminating anchor boxes, YOLOX simplifies the detection head and significantly reduces the number of heuristic parameters that need manual tuning during training.
 

--- a/docs/en/compare/yolov5-vs-yolox.md
+++ b/docs/en/compare/yolov5-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 vs YOLOX Comparison
 comments: true
 description: Compare YOLOv5 and YOLOX object detection models. Explore performance metrics, strengths, weaknesses, and use cases to choose the best fit for your needs.
 keywords: YOLOv5, YOLOX, object detection, model comparison, computer vision, Ultralytics, anchor-based, anchor-free, real-time detection, AI models

--- a/docs/en/compare/yolov6-vs-damo-yolo.md
+++ b/docs/en/compare/yolov6-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Discover a thorough technical comparison of YOLOv6-3.0 and DAMO-YOL
 keywords: YOLOv6-3.0, DAMO-YOLO, object detection comparison, YOLO models, computer vision, machine learning, model performance, deep learning, industrial AI
 ---
 
-# YOLOv6-3.0 vs DAMO-YOLO: A Technical Showdown in Real-Time Object Detection
+# YOLOv6-3.0 vs DAMO-YOLO
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible in real-time [object detection](https://docs.ultralytics.com/tasks/detect). Two notable contenders in this space are YOLOv6-3.0 and DAMO-YOLO. Both models introduce unique architectural innovations designed to maximize performance on industrial hardware. This guide provides a comprehensive technical comparison between these two models, exploring their architectures, training methodologies, and ideal use cases, while also introducing the next-generation advantages of Ultralytics models like YOLO26.
 

--- a/docs/en/compare/yolov6-vs-damo-yolo.md
+++ b/docs/en/compare/yolov6-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs DAMO-YOLO Comparison
 comments: true
 description: Discover a thorough technical comparison of YOLOv6-3.0 and DAMO-YOLO. Analyze architecture, performance, and use cases to pick the best object detection model.
 keywords: YOLOv6-3.0, DAMO-YOLO, object detection comparison, YOLO models, computer vision, machine learning, model performance, deep learning, industrial AI

--- a/docs/en/compare/yolov6-vs-efficientdet.md
+++ b/docs/en/compare/yolov6-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv6-3.0 and EfficientDet includ
 keywords: YOLOv6, EfficientDet, object detection, model comparison, YOLOv6-3.0, EfficientDet-d7, computer vision, benchmarks, architecture, real-time detection
 ---
 
-# YOLOv6-3.0 vs. EfficientDet: A Comprehensive Technical Comparison
+# YOLOv6-3.0 vs EfficientDet
 
 Choosing the optimal architecture for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) projects requires a deep understanding of the trade-offs between speed, accuracy, and deployment feasibility. This comparison page provides an in-depth analysis of two distinct object detection models: YOLOv6-3.0 and EfficientDet. While both models have contributed significantly to the field, modern edge deployments and rapid prototyping often benefit from more unified frameworks like the [Ultralytics Platform](https://docs.ultralytics.com/platform).
 

--- a/docs/en/compare/yolov6-vs-efficientdet.md
+++ b/docs/en/compare/yolov6-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs EfficientDet Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv6-3.0 and EfficientDet including benchmarks, architectures, and applications for optimal object detection model choice.
 keywords: YOLOv6, EfficientDet, object detection, model comparison, YOLOv6-3.0, EfficientDet-d7, computer vision, benchmarks, architecture, real-time detection

--- a/docs/en/compare/yolov6-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov6-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6-3.0 and PP-YOLOE+ models. Explore performance, archi
 keywords: YOLOv6-3.0, PP-YOLOE+, object detection, model comparison, computer vision, AI models, inference speed, accuracy, architecture, benchmarking
 ---
 
-# YOLOv6-3.0 vs PP-YOLOE+: Evaluating Industrial Object Detectors
+# YOLOv6-3.0 vs PP-YOLOE+
 
 When selecting a framework for real-time [object detection](https://docs.ultralytics.com/tasks/detect), machine learning engineers frequently evaluate a variety of high-performance architectures. Two notable models in the landscape of industrial applications are **YOLOv6-3.0** and **PP-YOLOE+**. Both models have pushed the boundaries of accuracy and speed, yet they are tailored for slightly different ecosystems and deployment hardware.
 

--- a/docs/en/compare/yolov6-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov6-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLOv6-3.0 and PP-YOLOE+ models. Explore performance, architecture, and use cases to choose the best object detection model for your needs.
 keywords: YOLOv6-3.0, PP-YOLOE+, object detection, model comparison, computer vision, AI models, inference speed, accuracy, architecture, benchmarking

--- a/docs/en/compare/yolov6-vs-rtdetr.md
+++ b/docs/en/compare/yolov6-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs RTDETRv2 Comparison
 comments: true
 description: Compare YOLOv6 and RTDETR for object detection. Explore their architectures, performances, and use cases to choose your optimal computer vision model.
 keywords: YOLOv6, RTDETR, object detection, model comparison, YOLO, Vision Transformers, CNN, real-time detection, Ultralytics, computer vision

--- a/docs/en/compare/yolov6-vs-rtdetr.md
+++ b/docs/en/compare/yolov6-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6 and RTDETR for object detection. Explore their archi
 keywords: YOLOv6, RTDETR, object detection, model comparison, YOLO, Vision Transformers, CNN, real-time detection, Ultralytics, computer vision
 ---
 
-# YOLOv6-3.0 vs RTDETRv2: A Duel Between Industrial CNNs and Real-Time Transformers
+# YOLOv6-3.0 vs RTDETRv2
 
 Choosing the optimal architecture for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) applications requires balancing speed, accuracy, and deployment constraints. In this comprehensive technical breakdown, we analyze **YOLOv6-3.0**, an industrial-grade Convolutional Neural Network (CNN) engineered for high-throughput GPU environments, against **RTDETRv2**, a state-of-the-art transformer-based model bringing attention mechanisms to real-time object detection.
 

--- a/docs/en/compare/yolov6-vs-yolo11.md
+++ b/docs/en/compare/yolov6-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and YOLOv6-3.0 for object detection. Explore archite
 keywords: YOLO11, YOLOv6-3.0, object detection, model comparison, Ultralytics, computer vision, real-time detection, performance metrics, deep learning
 ---
 
-# YOLOv6-3.0 vs YOLO11: A Deep Dive into Real-Time Object Detection
+# YOLOv6-3.0 vs YOLO11
 
 When evaluating computer vision models for high-performance applications, choosing the right architecture is critical. The evolution of vision AI has led to specialized models tailored for distinct environments. This comprehensive guide compares two prominent models in the ecosystem: the industrially focused YOLOv6-3.0 and the highly versatile [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11).
 

--- a/docs/en/compare/yolov6-vs-yolo11.md
+++ b/docs/en/compare/yolov6-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLO11 Comparison
 comments: true
 description: Compare YOLO11 and YOLOv6-3.0 for object detection. Explore architectures, metrics, and use cases to choose the best model for your needs.
 keywords: YOLO11, YOLOv6-3.0, object detection, model comparison, Ultralytics, computer vision, real-time detection, performance metrics, deep learning

--- a/docs/en/compare/yolov6-vs-yolo26.md
+++ b/docs/en/compare/yolov6-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6-3.0 and YOLO26 for object detection. Discover their 
 keywords: YOLOv6-3.0, YOLO26, object detection, model comparison, computer vision, benchmark, real-time detection, AI models, machine learning
 ---
 
-# YOLOv6-3.0 vs YOLO26: A Deep Dive into Real-Time Object Detection
+# YOLOv6-3.0 vs YOLO26
 
 The evolution of real-time [object detection](https://docs.ultralytics.com/tasks/detect) has brought forth incredible innovations, often polarizing the focus between industrial GPU throughput and versatile, edge-optimized architectures. In this comprehensive comparison, we explore the nuances between two heavyweights: the industrially focused **YOLOv6-3.0** and the newly released, natively end-to-end **Ultralytics YOLO26**.
 

--- a/docs/en/compare/yolov6-vs-yolo26.md
+++ b/docs/en/compare/yolov6-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLO26 Comparison
 comments: true
 description: Compare YOLOv6-3.0 and YOLO26 for object detection. Discover their performance, features, strengths, and use cases to choose the best model for your needs.
 keywords: YOLOv6-3.0, YOLO26, object detection, model comparison, computer vision, benchmark, real-time detection, AI models, machine learning

--- a/docs/en/compare/yolov6-vs-yolov10.md
+++ b/docs/en/compare/yolov6-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv10 and YOLOv6-3.0. Analyze th
 keywords: YOLOv10, YOLOv6-3.0, model comparison, object detection, Ultralytics, computer vision, AI models, real-time detection, edge AI, industrial AI
 ---
 
-# YOLOv6-3.0 vs. YOLOv10: Navigating Real-Time Object Detection Architectures
+# YOLOv6-3.0 vs YOLOv10
 
 The landscape of computer vision has grown increasingly complex, making the selection of an optimal model a critical decision for developers and machine learning engineers. When evaluating the [evolution of object detection and Ultralytics YOLO models](https://www.ultralytics.com/blog/the-evolution-of-object-detection-and-ultralytics-yolo-models), it is important to understand the trade-offs between different architectural approaches. This guide provides a comprehensive technical comparison between YOLOv6-3.0 and YOLOv10, two models that offer distinct advantages for industrial and edge deployments.
 

--- a/docs/en/compare/yolov6-vs-yolov10.md
+++ b/docs/en/compare/yolov6-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOv10 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv10 and YOLOv6-3.0. Analyze their architectures, benchmarks, strengths, and use cases for your AI projects.
 keywords: YOLOv10, YOLOv6-3.0, model comparison, object detection, Ultralytics, computer vision, AI models, real-time detection, edge AI, industrial AI

--- a/docs/en/compare/yolov6-vs-yolov5.md
+++ b/docs/en/compare/yolov6-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Compare YOLOv5 and YOLOv6-3.0 models. Explore benchmarks, architect
 keywords: YOLOv5, YOLOv6-3.0, object detection, model comparison, computer vision, mAP, inference speed, real-time detection, Ultralytics, YOLO models
 ---
 
-# YOLOv6-3.0 vs. YOLOv5: A Comprehensive Technical Comparison
+# YOLOv6-3.0 vs YOLOv5
 
 The evolution of real-time object detection has seen multiple architectures optimized for different deployment scenarios. In this deep dive, we compare two prominent models: the industry-focused **YOLOv6-3.0** and the foundational, highly versatile **Ultralytics YOLOv5**. Understanding the architectural choices, performance metrics, and ecosystem support of each will help you select the optimal [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) framework for your real-world applications.
 

--- a/docs/en/compare/yolov6-vs-yolov5.md
+++ b/docs/en/compare/yolov6-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOv5 Comparison
 comments: true
 description: Compare YOLOv5 and YOLOv6-3.0 models. Explore benchmarks, architectures, speed, and accuracy to choose the best object detection model for your needs.
 keywords: YOLOv5, YOLOv6-3.0, object detection, model comparison, computer vision, mAP, inference speed, real-time detection, Ultralytics, YOLO models

--- a/docs/en/compare/yolov6-vs-yolov7.md
+++ b/docs/en/compare/yolov6-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6-3.0 and YOLOv7 models for object detection. Explore 
 keywords: YOLOv6, YOLOv7, object detection, model comparison, computer vision, machine learning, performance benchmarks, YOLO models
 ---
 
-# YOLOv6-3.0 vs YOLOv7: Navigating Real-Time Object Detection Architectures
+# YOLOv6-3.0 vs YOLOv7
 
 The evolution of real-time computer vision has been marked by rapid advancements in architectural efficiency and training methodologies. Two prominent models that significantly impacted the landscape are **YOLOv6-3.0** and **YOLOv7**. Both frameworks introduced novel techniques to balance inference speed with detection accuracy, targeting deployments ranging from high-end server GPUs to edge devices.
 

--- a/docs/en/compare/yolov6-vs-yolov7.md
+++ b/docs/en/compare/yolov6-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOv7 Comparison
 comments: true
 description: Compare YOLOv6-3.0 and YOLOv7 models for object detection. Explore architecture, performance benchmarks, use cases, and find the best for your needs.
 keywords: YOLOv6, YOLOv7, object detection, model comparison, computer vision, machine learning, performance benchmarks, YOLO models

--- a/docs/en/compare/yolov6-vs-yolov8.md
+++ b/docs/en/compare/yolov6-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLOv6-3.0 and YOLOv8 for object detection. Explore their architectures, strengths, and use cases to choose the best fit for your project.
 keywords: YOLOv6, YOLOv8, object detection, model comparison, computer vision, machine learning, AI, Ultralytics, neural networks, YOLO models

--- a/docs/en/compare/yolov6-vs-yolov8.md
+++ b/docs/en/compare/yolov6-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6-3.0 and YOLOv8 for object detection. Explore their a
 keywords: YOLOv6, YOLOv8, object detection, model comparison, computer vision, machine learning, AI, Ultralytics, neural networks, YOLO models
 ---
 
-# YOLOv6-3.0 vs YOLOv8: Navigating the Evolution of Real-Time Object Detection
+# YOLOv6-3.0 vs YOLOv8
 
 The field of computer vision has witnessed tremendous growth, with models continually pushing the boundaries of speed and accuracy. When selecting an architecture for deployment, developers often compare specialized industrial models with versatile, multi-task frameworks. This technical comparison provides an in-depth analysis of **YOLOv6-3.0** and **YOLOv8**, evaluating their architectures, performance metrics, and ideal deployment environments.
 

--- a/docs/en/compare/yolov6-vs-yolov9.md
+++ b/docs/en/compare/yolov6-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOv9 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv6-3.0 vs YOLOv9, highlighting performance, architecture, metrics, and use cases to choose the best object detection model.
 keywords: YOLOv6, YOLOv9, object detection, model comparison, performance metrics, computer vision, neural networks, Ultralytics, real-time detection

--- a/docs/en/compare/yolov6-vs-yolov9.md
+++ b/docs/en/compare/yolov6-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv6-3.0 vs YOLOv9, highlighting
 keywords: YOLOv6, YOLOv9, object detection, model comparison, performance metrics, computer vision, neural networks, Ultralytics, real-time detection
 ---
 
-# YOLOv6-3.0 vs. YOLOv9: A Technical Deep Dive into Modern Object Detection
+# YOLOv6-3.0 vs YOLOv9
 
 The landscape of real-time object detection continues to evolve, driven by demands for higher accuracy, lower latency, and better hardware utilization. This comprehensive comparison examines two significant milestones in the field: **YOLOv6-3.0**, developed for industrial throughput, and **YOLOv9**, which introduced novel architectures to overcome deep learning information bottlenecks.
 

--- a/docs/en/compare/yolov6-vs-yolox.md
+++ b/docs/en/compare/yolov6-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare YOLOv6-3.0 and YOLOX architectures, performance, and applic
 keywords: YOLOv6-3.0, YOLOX, object detection, model comparison, computer vision, performance metrics, real-time applications, deep learning
 ---
 
-# YOLOv6-3.0 vs YOLOX: Evaluating Industrial Object Detectors
+# YOLOv6-3.0 vs YOLOX
 
 The landscape of computer vision has been heavily shaped by models aiming to bridge the gap between academic research and industrial application. When evaluating [object detection](https://docs.ultralytics.com/tasks/detect) frameworks tailored for high-performance deployment, **YOLOv6-3.0** and **YOLOX** frequently emerge as prominent contenders. Both models introduce distinct architectural philosophies to maximize throughput and precision, yet they differ significantly in their design choices and primary deployment targets.
 

--- a/docs/en/compare/yolov6-vs-yolox.md
+++ b/docs/en/compare/yolov6-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv6-3.0 vs YOLOX Comparison
 comments: true
 description: Compare YOLOv6-3.0 and YOLOX architectures, performance, and applications. Find the best object detection model for your computer vision needs.
 keywords: YOLOv6-3.0, YOLOX, object detection, model comparison, computer vision, performance metrics, real-time applications, deep learning

--- a/docs/en/compare/yolov7-vs-damo-yolo.md
+++ b/docs/en/compare/yolov7-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs DAMO-YOLO Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv7 and DAMO-YOLO, analyzing their architecture, performance, and best use cases for object detection projects.
 keywords: YOLOv7,DAMO-YOLO,object detection,YOLO comparison,AI models,deep learning,computer vision,model benchmarks,real-time detection

--- a/docs/en/compare/yolov7-vs-damo-yolo.md
+++ b/docs/en/compare/yolov7-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv7 and DAMO-YOLO, analyzing th
 keywords: YOLOv7,DAMO-YOLO,object detection,YOLO comparison,AI models,deep learning,computer vision,model benchmarks,real-time detection
 ---
 
-# YOLOv7 vs. DAMO-YOLO: A Comprehensive Technical Comparison
+# YOLOv7 vs DAMO-YOLO
 
 The landscape of real-time object detection is continually evolving, with researchers and engineers striving to find the optimal balance between speed and accuracy. In this technical comparison, we will dive deep into two notable architectures from 2022: **YOLOv7** and **DAMO-YOLO**. Both models introduced novel concepts to the computer vision community, addressing different challenges in model training, architectural design, and deployment.
 

--- a/docs/en/compare/yolov7-vs-efficientdet.md
+++ b/docs/en/compare/yolov7-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs EfficientDet Comparison
 comments: true
 description: Compare YOLOv7 and EfficientDet for object detection. Discover their performance, features, strengths, and use cases to choose the best model for your needs.
 keywords: YOLOv7, EfficientDet, object detection, model comparison, computer vision, benchmark, real-time detection, AI models, machine learning

--- a/docs/en/compare/yolov7-vs-efficientdet.md
+++ b/docs/en/compare/yolov7-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare YOLOv7 and EfficientDet for object detection. Discover thei
 keywords: YOLOv7, EfficientDet, object detection, model comparison, computer vision, benchmark, real-time detection, AI models, machine learning
 ---
 
-# Comprehensive Comparison: YOLOv7 vs EfficientDet for Object Detection
+# YOLOv7 vs EfficientDet
 
 Selecting the optimal neural network architecture is the foundation of any successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) project. This guide provides a detailed technical comparison between two pivotal models in the history of [object detection architectures](https://www.ultralytics.com/glossary/object-detection-architectures): **YOLOv7** and **EfficientDet**. By examining their architectural innovations, training methodologies, and ideal deployment scenarios, developers can make informed decisions. We will also explore how modern advancements, particularly the groundbreaking [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26), have redefined the current state-of-the-art.
 

--- a/docs/en/compare/yolov7-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov7-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLOv7 and PP-YOLOE+ for object detection. Explore their pe
 keywords: YOLOv7, PP-YOLOE+, object detection models, model comparison, YOLO models, AI benchmarking, computer vision, anchor-free detection, efficient models
 ---
 
-# YOLOv7 vs PP-YOLOE+: A Comprehensive Comparison of Real-Time Detectors
+# YOLOv7 vs PP-YOLOE+
 
 When evaluating state-of-the-art computer vision models for production pipelines, developers often weigh the advantages of different architectures. Two notable models in the object detection landscape are [YOLOv7](https://github.com/WongKinYiu/yolov7) and [PP-YOLOE+](https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.8.1/configs/ppyoloe/README.md). This guide provides a detailed technical comparison of their architectures, performance metrics, and ideal deployment scenarios to help you make an informed decision for your next computer vision project.
 

--- a/docs/en/compare/yolov7-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov7-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLOv7 and PP-YOLOE+ for object detection. Explore their performance, architectures, and best use cases to select the ideal model for your needs.
 keywords: YOLOv7, PP-YOLOE+, object detection models, model comparison, YOLO models, AI benchmarking, computer vision, anchor-free detection, efficient models

--- a/docs/en/compare/yolov7-vs-rtdetr.md
+++ b/docs/en/compare/yolov7-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare YOLOv7 and RTDETRv2 for object detection. Explore architect
 keywords: YOLOv7, RTDETRv2, model comparison, object detection, computer vision, machine learning, real-time detection, AI models, Vision Transformers
 ---
 
-# YOLOv7 vs RTDETRv2: A Technical Comparison for Real-Time Object Detection
+# YOLOv7 vs RTDETRv2
 
 The landscape of computer vision continues to evolve rapidly, heavily influenced by the competition between Convolutional Neural Networks (CNNs) and Vision Transformers (ViTs). This technical comparison delves into two heavyweight architectures: **YOLOv7**, a highly optimized CNN-based object detector, and **RTDETRv2**, a state-of-the-art Real-Time Detection Transformer.
 

--- a/docs/en/compare/yolov7-vs-rtdetr.md
+++ b/docs/en/compare/yolov7-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs RTDETRv2 Comparison
 comments: true
 description: Compare YOLOv7 and RTDETRv2 for object detection. Explore architecture, performance, and use cases to pick the best model for your project.
 keywords: YOLOv7, RTDETRv2, model comparison, object detection, computer vision, machine learning, real-time detection, AI models, Vision Transformers

--- a/docs/en/compare/yolov7-vs-yolo11.md
+++ b/docs/en/compare/yolov7-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Explore the strengths, benchmarks, and use cases of YOLO11 and YOLO
 keywords: YOLO11, YOLOv7, object detection, model comparison, YOLO models, deep learning, computer vision, Ultralytics, benchmarks, real-time detection
 ---
 
-# YOLOv7 vs YOLO11: A Comprehensive Technical Comparison
+# YOLOv7 vs YOLO11
 
 The landscape of computer vision has rapidly evolved over the past few years. For developers and researchers choosing the right object detection framework, understanding the architectural and practical differences between generation-defining models is critical. This guide provides a detailed technical comparison between the academic breakthrough of [YOLOv7](https://docs.ultralytics.com/models/yolov7) and the highly refined, production-ready [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11).
 

--- a/docs/en/compare/yolov7-vs-yolo11.md
+++ b/docs/en/compare/yolov7-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLO11 Comparison
 comments: true
 description: Explore the strengths, benchmarks, and use cases of YOLO11 and YOLOv7 object detection models. Find the best fit for your project in this in-depth guide.
 keywords: YOLO11, YOLOv7, object detection, model comparison, YOLO models, deep learning, computer vision, Ultralytics, benchmarks, real-time detection

--- a/docs/en/compare/yolov7-vs-yolo26.md
+++ b/docs/en/compare/yolov7-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLO26 Comparison
 comments: true
 description: Compare YOLOv7 and YOLO26 for object detection. Explore their architectures, performance benchmarks, and ideal use cases to choose the best model.
 keywords: YOLOv7, YOLO26, object detection, model comparison, computer vision, deep learning, real-time detection, accuracy, performance benchmarks

--- a/docs/en/compare/yolov7-vs-yolo26.md
+++ b/docs/en/compare/yolov7-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare YOLOv7 and YOLO26 for object detection. Explore their archi
 keywords: YOLOv7, YOLO26, object detection, model comparison, computer vision, deep learning, real-time detection, accuracy, performance benchmarks
 ---
 
-# YOLOv7 vs YOLO26: A Generational Leap in Real-Time Object Detection
+# YOLOv7 vs YOLO26
 
 The evolution of computer vision has been marked by significant milestones, and comparing legacy architectures with modern state-of-the-art models provides valuable insights for ML Engineers. This technical comparison delves into the differences between the highly influential [YOLOv7](https://github.com/WongKinYiu/yolov7) and the revolutionary [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26), highlighting advancements in architecture, training methodologies, and deployment efficiency.
 

--- a/docs/en/compare/yolov7-vs-yolov10.md
+++ b/docs/en/compare/yolov7-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOv10 Comparison
 comments: true
 description: Discover the key differences between YOLOv7 and YOLOv10, from architecture to performance benchmarks, to choose the optimal model for your needs.
 keywords: YOLOv7, YOLOv10, object detection, model comparison, performance benchmarks, computer vision, Ultralytics YOLO, edge deployment, real-time AI

--- a/docs/en/compare/yolov7-vs-yolov10.md
+++ b/docs/en/compare/yolov7-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOv7 and YOLOv10, from archi
 keywords: YOLOv7, YOLOv10, object detection, model comparison, performance benchmarks, computer vision, Ultralytics YOLO, edge deployment, real-time AI
 ---
 
-# YOLOv7 vs YOLOv10: The Evolution of Real-Time Object Detection
+# YOLOv7 vs YOLOv10
 
 The field of computer vision has witnessed remarkable advancements over the past few years, with the YOLO (You Only Look Once) family of models leading the charge in real-time object detection. Choosing the right architecture for your computer vision projects requires a deep understanding of the available options. In this comprehensive technical comparison, we will explore the key differences between two landmark architectures: **YOLOv7** and **YOLOv10**.
 

--- a/docs/en/compare/yolov7-vs-yolov5.md
+++ b/docs/en/compare/yolov7-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOv5 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv7 and YOLOv5. Learn their key features, performance metrics, strengths, and use cases to choose the right model.
 keywords: YOLOv7, YOLOv5, object detection, model comparison, YOLO models, machine learning, deep learning, performance benchmarks, architecture, AI models

--- a/docs/en/compare/yolov7-vs-yolov5.md
+++ b/docs/en/compare/yolov7-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv7 and YOLOv5. Learn their key
 keywords: YOLOv7, YOLOv5, object detection, model comparison, YOLO models, machine learning, deep learning, performance benchmarks, architecture, AI models
 ---
 
-# YOLOv7 vs YOLOv5: A Technical Comparison of Real-Time Detectors
+# YOLOv7 vs YOLOv5
 
 When building modern [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipelines, selecting the right object detection architecture is critical for balancing accuracy, inference speed, and resource utilization. This comprehensive comparison examines two highly influential models in the computer vision space: YOLOv7 and Ultralytics YOLOv5.
 

--- a/docs/en/compare/yolov7-vs-yolov6.md
+++ b/docs/en/compare/yolov7-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Explore YOLOv7 vs YOLOv6-3.0 for object detection. Compare architec
 keywords: YOLOv7, YOLOv6-3.0, object detection, model comparison, computer vision, AI models, YOLO, deep learning, Ultralytics, performance benchmarks
 ---
 
-# YOLOv7 vs YOLOv6-3.0: A Comprehensive Technical Comparison
+# YOLOv7 vs YOLOv6-3.0
 
 The field of computer vision is constantly evolving, with new object detection models continuously pushing the boundaries of speed and accuracy. Two significant milestones in this journey are YOLOv7 and YOLOv6-3.0. Both models introduced unique architectural innovations designed to maximize throughput and precision for real-world applications. This page provides an in-depth technical analysis of both architectures, comparing their performance, training methodologies, and ideal use cases to help you make an informed decision for your next artificial intelligence project.
 

--- a/docs/en/compare/yolov7-vs-yolov6.md
+++ b/docs/en/compare/yolov7-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOv6-3.0 Comparison
 comments: true
 description: Explore YOLOv7 vs YOLOv6-3.0 for object detection. Compare architectures, benchmarks, and applications to select the best model for your project.
 keywords: YOLOv7, YOLOv6-3.0, object detection, model comparison, computer vision, AI models, YOLO, deep learning, Ultralytics, performance benchmarks

--- a/docs/en/compare/yolov7-vs-yolov8.md
+++ b/docs/en/compare/yolov7-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOv8 Comparison
 comments: true
 description: Compare YOLOv7 and YOLOv8 for object detection. Explore performance, architecture, and use cases to choose the best model for your vision tasks.
 keywords: YOLOv7, YOLOv8, object detection, model comparison, computer vision, real-time detection, performance benchmarks, deep learning, Ultralytics

--- a/docs/en/compare/yolov7-vs-yolov8.md
+++ b/docs/en/compare/yolov7-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLOv7 and YOLOv8 for object detection. Explore performance
 keywords: YOLOv7, YOLOv8, object detection, model comparison, computer vision, real-time detection, performance benchmarks, deep learning, Ultralytics
 ---
 
-# YOLOv7 vs YOLOv8: A Technical Comparison of Real-Time Detectors
+# YOLOv7 vs YOLOv8
 
 The rapid evolution of computer vision has produced an array of powerful tools for developers and researchers. When deciding on the right architecture for an [object detection](https://docs.ultralytics.com/tasks/detect) pipeline, comparing established models is essential. This technical guide provides a deep dive into the architectures, performance metrics, and ideal use cases of two highly influential models: YOLOv7 and Ultralytics YOLOv8.
 

--- a/docs/en/compare/yolov7-vs-yolov9.md
+++ b/docs/en/compare/yolov7-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Explore the differences between YOLOv7 and YOLOv9. Compare architec
 keywords: YOLOv7, YOLOv9, object detection, model comparison, YOLO architecture, AI models, computer vision, machine learning, Ultralytics
 ---
 
-# YOLOv7 vs YOLOv9: A Technical Deep Dive into Modern Object Detection
+# YOLOv7 vs YOLOv9
 
 The landscape of real-time [object detection](https://www.ultralytics.com/glossary/object-detection) has evolved rapidly, with each new iteration pushing the boundaries of what is possible on edge devices and cloud servers alike. When evaluating architectures for computer vision projects, developers frequently compare established benchmarks with newer innovations. This comprehensive guide compares two pivotal milestones in the YOLO family: [YOLOv7](https://docs.ultralytics.com/models/yolov7) and [YOLOv9](https://docs.ultralytics.com/models/yolov9).
 

--- a/docs/en/compare/yolov7-vs-yolov9.md
+++ b/docs/en/compare/yolov7-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOv9 Comparison
 comments: true
 description: Explore the differences between YOLOv7 and YOLOv9. Compare architecture, performance, and use cases to choose the best model for object detection.
 keywords: YOLOv7, YOLOv9, object detection, model comparison, YOLO architecture, AI models, computer vision, machine learning, Ultralytics

--- a/docs/en/compare/yolov7-vs-yolox.md
+++ b/docs/en/compare/yolov7-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv7 vs YOLOX Comparison
 comments: true
 description: Explore YOLOv7 vs YOLOX in this detailed comparison. Learn their architectures, performance metrics, and best use cases for object detection.
 keywords: YOLOv7, YOLOX, object detection, YOLO comparison, YOLO models, computer vision, model benchmarks, real-time AI, machine learning

--- a/docs/en/compare/yolov7-vs-yolox.md
+++ b/docs/en/compare/yolov7-vs-yolox.md
@@ -39,7 +39,7 @@ YOLOX took a different path by shifting the paradigm back to anchor-free detecti
 - **Date:** 2021-07-18
 - **Arxiv:** [https://arxiv.org/abs/2107.08430](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [https://github.com/Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Docs:** [YOLOX Official Docs](https://yolox.readthedocs.io/en/latest/)
+- **Docs:** [YOLOX Official Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 [Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX){ .md-button }
 

--- a/docs/en/compare/yolov7-vs-yolox.md
+++ b/docs/en/compare/yolov7-vs-yolox.md
@@ -4,7 +4,7 @@ description: Explore YOLOv7 vs YOLOX in this detailed comparison. Learn their ar
 keywords: YOLOv7, YOLOX, object detection, YOLO comparison, YOLO models, computer vision, model benchmarks, real-time AI, machine learning
 ---
 
-# YOLOv7 and YOLOX: A Technical Analysis of Real-Time Detectors
+# YOLOv7 vs YOLOX
 
 The evolution of computer vision has been marked by rapid advancements in real-time object detection. Two pivotal milestones in this journey are YOLOv7 and YOLOX. While both models pushed the boundaries of speed and accuracy, they adopted different architectural philosophies to achieve their results. This guide provides a comprehensive technical comparison between these two powerful models, helping you choose the right architecture for your computer vision projects.
 

--- a/docs/en/compare/yolov8-vs-damo-yolo.md
+++ b/docs/en/compare/yolov8-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and DAMO-YOLO object detection models. Explore diffe
 keywords: YOLOv8,DAMO-YOLO,object detection,computer vision,model comparison,YOLO,Ultralytics,deep learning,accuracy,inference speed
 ---
 
-# YOLOv8 vs. DAMO-YOLO: A Comprehensive Technical Comparison of Object Detection Models
+# YOLOv8 vs DAMO-YOLO
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible on edge devices and massive cloud clusters. In this technical deep dive, we compare two prominent real-time object detection models: **YOLOv8** and **DAMO-YOLO**. By examining their architectures, performance metrics, and training methodologies, ML engineers can make informed decisions for their deployment pipelines.
 

--- a/docs/en/compare/yolov8-vs-damo-yolo.md
+++ b/docs/en/compare/yolov8-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs DAMO-YOLO Comparison
 comments: true
 description: Compare YOLOv8 and DAMO-YOLO object detection models. Explore differences in performance, architecture, and applications to choose the best fit.
 keywords: YOLOv8,DAMO-YOLO,object detection,computer vision,model comparison,YOLO,Ultralytics,deep learning,accuracy,inference speed

--- a/docs/en/compare/yolov8-vs-efficientdet.md
+++ b/docs/en/compare/yolov8-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and EfficientDet for object detection. Explore their
 keywords: YOLOv8, EfficientDet, object detection, model comparison, computer vision, deep learning, real-time detection, accuracy, performance benchmarks
 ---
 
-# Ultralytics YOLOv8 vs. EfficientDet: A Comprehensive Technical Comparison
+# YOLOv8 vs EfficientDet
 
 In the rapidly evolving field of [object detection](https://en.wikipedia.org/wiki/Object_detection), selecting the optimal neural network architecture is critical for balancing accuracy, inference speed, and deployment feasibility. This technical deep dive compares two highly influential architectures: **[Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8)**, a versatile standard in the modern computer vision ecosystem, and **EfficientDet**, a foundational model from Google known for its compound scaling strategy.
 

--- a/docs/en/compare/yolov8-vs-efficientdet.md
+++ b/docs/en/compare/yolov8-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs EfficientDet Comparison
 comments: true
 description: Compare YOLOv8 and EfficientDet for object detection. Explore their architectures, performance benchmarks, and ideal use cases to choose the best model.
 keywords: YOLOv8, EfficientDet, object detection, model comparison, computer vision, deep learning, real-time detection, accuracy, performance benchmarks

--- a/docs/en/compare/yolov8-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov8-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOv8 and PP-YOLOE+ in this t
 keywords: YOLOv8, PP-YOLOE+, object detection, computer vision, model comparison, YOLO models, Ultralytics, PaddlePaddle, deep learning
 ---
 
-# YOLOv8 vs. PP-YOLOE+: Evaluating Modern Real-Time Object Detection Architectures
+# YOLOv8 vs PP-YOLOE+
 
 In the rapidly evolving field of [computer vision](https://en.wikipedia.org/wiki/Computer_vision), selecting the right model for [object detection](https://en.wikipedia.org/wiki/Object_detection) is critical for achieving a balance between inference speed and accuracy. Two prominent models that have significantly impacted the industry are [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) and [PP-YOLOE+](https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.8.1/configs/ppyoloe/README.md). This guide provides a comprehensive technical comparison to help developers and machine learning engineers understand the nuances of their architectures, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/yolov8-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov8-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs PP-YOLOE+ Comparison
 comments: true
 description: Discover the key differences between YOLOv8 and PP-YOLOE+ in this technical comparison. Learn which model suits your object detection needs best.
 keywords: YOLOv8, PP-YOLOE+, object detection, computer vision, model comparison, YOLO models, Ultralytics, PaddlePaddle, deep learning

--- a/docs/en/compare/yolov8-vs-rtdetr.md
+++ b/docs/en/compare/yolov8-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Explore the detailed comparison of YOLOv8 and RTDETRv2 models for o
 keywords: YOLOv8,RTDETRv2,object detection,model comparison,performance metrics,real-time detection,transformer-based models,computer vision,Ultralytics
 ---
 
-# YOLOv8 vs. RTDETRv2: An In-Depth Technical Comparison
+# YOLOv8 vs RTDETRv2
 
 The landscape of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible in real-time object detection. Two prominent models that have garnered significant attention are Ultralytics YOLOv8 and Baidu's RTDETRv2. This guide provides a comprehensive technical comparison between these two powerful models, exploring their architectures, performance metrics, and ideal deployment scenarios.
 

--- a/docs/en/compare/yolov8-vs-rtdetr.md
+++ b/docs/en/compare/yolov8-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs RTDETRv2 Comparison
 comments: true
 description: Explore the detailed comparison of YOLOv8 and RTDETRv2 models for object detection. Discover their architecture, performance, and best use cases.
 keywords: YOLOv8,RTDETRv2,object detection,model comparison,performance metrics,real-time detection,transformer-based models,computer vision,Ultralytics

--- a/docs/en/compare/yolov8-vs-yolo11.md
+++ b/docs/en/compare/yolov8-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and YOLO11 for object detection. Explore their perfo
 keywords: YOLOv8, YOLO11, object detection, Ultralytics, YOLO comparison, machine learning, computer vision, inference speed, model accuracy
 ---
 
-# YOLOv8 vs YOLO11: A Comprehensive Technical Comparison of Real-Time Vision Models
+# YOLOv8 vs YOLO11
 
 The rapid evolution of computer vision has been heavily driven by continuous advancements in real-time object detection frameworks. For developers and researchers navigating the modern landscape, choosing the right model is critical to balancing accuracy, speed, and resource efficiency. In this technical comparison, we will explore the differences between two foundational models from the [Ultralytics](https://www.ultralytics.com) ecosystem: [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) and [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11).
 

--- a/docs/en/compare/yolov8-vs-yolo11.md
+++ b/docs/en/compare/yolov8-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLO11 Comparison
 comments: true
 description: Compare YOLOv8 and YOLO11 for object detection. Explore their performance, architecture, and best-use cases to find the right model for your needs.
 keywords: YOLOv8, YOLO11, object detection, Ultralytics, YOLO comparison, machine learning, computer vision, inference speed, model accuracy

--- a/docs/en/compare/yolov8-vs-yolo26.md
+++ b/docs/en/compare/yolov8-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and YOLO26 for object detection. Explore their archi
 keywords: YOLOv8,YOLO26,object detection,model comparison,YOLO,Ultralytics,deep learning,computer vision,benchmarking,real-time detection
 ---
 
-# YOLOv8 vs YOLO26: The Evolution of Ultralytics Real-Time Object Detection
+# YOLOv8 vs YOLO26
 
 The field of computer vision has witnessed remarkable advancements over the last few years. Among the most popular architectures for real-time applications are the models developed by [Ultralytics](https://www.ultralytics.com/). This comprehensive guide provides a detailed technical comparison between the groundbreaking [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) and the latest state-of-the-art [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26). We will analyze their architectures, performance metrics, and ideal use cases to help you choose the right model for your deployment.
 

--- a/docs/en/compare/yolov8-vs-yolo26.md
+++ b/docs/en/compare/yolov8-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLO26 Comparison
 comments: true
 description: Compare YOLOv8 and YOLO26 for object detection. Explore their architectures, performance benchmarks, and ideal use cases to choose the best model.
 keywords: YOLOv8,YOLO26,object detection,model comparison,YOLO,Ultralytics,deep learning,computer vision,benchmarking,real-time detection

--- a/docs/en/compare/yolov8-vs-yolov10.md
+++ b/docs/en/compare/yolov8-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Compare Ultralytics YOLOv8 and YOLOv10. Explore key differences in 
 keywords: YOLOv8 vs YOLOv10, YOLOv8 comparison, YOLOv10 performance, YOLO models, object detection, Ultralytics, computer vision, model efficiency, YOLO architecture
 ---
 
-# YOLOv8 vs YOLOv10: A Comprehensive Technical Comparison
+# YOLOv8 vs YOLOv10
 
 The evolution of real-time [object detection](https://docs.ultralytics.com/tasks/detect) has been moving at an unprecedented pace. As developers and researchers look to integrate the most efficient and accurate computer vision models into their pipelines, comparing leading architectures becomes essential. In this deep dive, we compare Ultralytics YOLOv8 and YOLOv10, examining their architectural differences, performance metrics, and ideal deployment scenarios to help you make an informed decision for your next AI project.
 

--- a/docs/en/compare/yolov8-vs-yolov10.md
+++ b/docs/en/compare/yolov8-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOv10 Comparison
 comments: true
 description: Compare Ultralytics YOLOv8 and YOLOv10. Explore key differences in architecture, efficiency, use cases, and find the perfect model for your needs.
 keywords: YOLOv8 vs YOLOv10, YOLOv8 comparison, YOLOv10 performance, YOLO models, object detection, Ultralytics, computer vision, model efficiency, YOLO architecture

--- a/docs/en/compare/yolov8-vs-yolov5.md
+++ b/docs/en/compare/yolov8-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOv5 Comparison
 comments: true
 description: Discover key differences between YOLOv8 and YOLOv5. Compare speed, accuracy, use cases, and more to choose the ideal model for your computer vision needs.
 keywords: YOLOv8, YOLOv5, object detection, YOLO comparison, computer vision, model comparison, speed, accuracy, Ultralytics, deep learning

--- a/docs/en/compare/yolov8-vs-yolov5.md
+++ b/docs/en/compare/yolov8-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Discover key differences between YOLOv8 and YOLOv5. Compare speed, 
 keywords: YOLOv8, YOLOv5, object detection, YOLO comparison, computer vision, model comparison, speed, accuracy, Ultralytics, deep learning
 ---
 
-# YOLOv8 vs. YOLOv5: A Comprehensive Technical Comparison
+# YOLOv8 vs YOLOv5
 
 Choosing the right computer vision architecture is a critical step in building robust machine learning pipelines. In this detailed technical comparison, we explore the differences between two of the most popular models in the vision AI ecosystem: **YOLOv8** and **YOLOv5**. Both models were developed by Ultralytics and have significantly shaped the landscape of real-time [object detection](https://docs.ultralytics.com/tasks/detect), setting industry standards for speed, accuracy, and ease of use.
 

--- a/docs/en/compare/yolov8-vs-yolov6.md
+++ b/docs/en/compare/yolov8-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOv6-3.0 Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLOv8 and YOLOv6-3.0. Learn about architecture, performance, and use cases for real-time object detection.
 keywords: YOLOv8, YOLOv6-3.0, object detection, machine learning, computer vision, real-time detection, model comparison, Ultralytics

--- a/docs/en/compare/yolov8-vs-yolov6.md
+++ b/docs/en/compare/yolov8-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLOv8 and YOLOv6-3.0. L
 keywords: YOLOv8, YOLOv6-3.0, object detection, machine learning, computer vision, real-time detection, model comparison, Ultralytics
 ---
 
-# YOLOv8 vs YOLOv6-3.0: A Comprehensive Technical Comparison
+# YOLOv8 vs YOLOv6-3.0
 
 The landscape of real-time computer vision is constantly evolving, driven by the demand for faster, more accurate, and more versatile models. Two of the most prominent architectures that emerged in early 2023 are [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) and YOLOv6-3.0 by Meituan. Both models push the boundaries of state-of-the-art performance, but they cater to slightly different development philosophies and deployment scenarios.
 

--- a/docs/en/compare/yolov8-vs-yolov7.md
+++ b/docs/en/compare/yolov8-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Explore a detailed comparison of YOLOv8 and YOLOv7 models. Learn th
 keywords: YOLOv8, YOLOv7, object detection, computer vision, model comparison, YOLO performance, AI models, machine learning, Ultralytics
 ---
 
-# YOLOv8 vs YOLOv7: A Comprehensive Technical Comparison
+# YOLOv8 vs YOLOv7
 
 The field of computer vision is constantly evolving, with new architectures pushing the boundaries of what is possible in real-time object detection. In this deep dive, we compare two highly influential models: **Ultralytics YOLOv8** and **YOLOv7**. Both models have significantly impacted the developer community and academic research, offering unique approaches to solving complex visual tasks.
 

--- a/docs/en/compare/yolov8-vs-yolov7.md
+++ b/docs/en/compare/yolov8-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOv7 Comparison
 comments: true
 description: Explore a detailed comparison of YOLOv8 and YOLOv7 models. Learn their strengths, performance benchmarks, and ideal use cases for object detection.
 keywords: YOLOv8, YOLOv7, object detection, computer vision, model comparison, YOLO performance, AI models, machine learning, Ultralytics

--- a/docs/en/compare/yolov8-vs-yolov9.md
+++ b/docs/en/compare/yolov8-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and YOLOv9 models for object detection. Explore thei
 keywords: YOLOv8, YOLOv9, object detection, model comparison, Ultralytics, performance metrics, real-time AI, computer vision, YOLO series
 ---
 
-# YOLOv8 vs. YOLOv9: A Comprehensive Technical Comparison of Real-Time Object Detectors
+# YOLOv8 vs YOLOv9
 
 The evolution of real-time object detection has been characterized by a constant push for better accuracy, lower latency, and improved hardware utilization. Two major milestones in this journey are [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8) and [YOLOv9](https://docs.ultralytics.com/models/yolov9). While both models represent state-of-the-art capabilities in [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv), they cater to different deployment needs, architectural philosophies, and developer ecosystems.
 

--- a/docs/en/compare/yolov8-vs-yolov9.md
+++ b/docs/en/compare/yolov8-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOv9 Comparison
 comments: true
 description: Compare YOLOv8 and YOLOv9 models for object detection. Explore their accuracy, speed, resources, and use cases to choose the best model for your needs.
 keywords: YOLOv8, YOLOv9, object detection, model comparison, Ultralytics, performance metrics, real-time AI, computer vision, YOLO series

--- a/docs/en/compare/yolov8-vs-yolox.md
+++ b/docs/en/compare/yolov8-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv8 vs YOLOX Comparison
 comments: true
 description: Compare YOLOv8 and YOLOX models for object detection. Discover strengths, weaknesses, benchmarks, and choose the right model for your application.
 keywords: YOLOv8, YOLOX, object detection, model comparison, Ultralytics, computer vision, anchor-free models, AI benchmarks

--- a/docs/en/compare/yolov8-vs-yolox.md
+++ b/docs/en/compare/yolov8-vs-yolox.md
@@ -4,7 +4,7 @@ description: Compare YOLOv8 and YOLOX models for object detection. Discover stre
 keywords: YOLOv8, YOLOX, object detection, model comparison, Ultralytics, computer vision, anchor-free models, AI benchmarks
 ---
 
-# YOLOv8 vs YOLOX: Analyzing Anchor-Free Object Detection Models
+# YOLOv8 vs YOLOX
 
 The landscape of computer vision has been heavily shaped by the continuous evolution of real-time object detection architectures. Two prominent milestones in this journey are [Ultralytics YOLOv8](https://docs.ultralytics.com/models/yolov8) and YOLOX. While both models embrace an anchor-free design paradigm to streamline bounding box predictions, they represent different eras and philosophies in deep learning research and deployment ecosystem development.
 

--- a/docs/en/compare/yolov8-vs-yolox.md
+++ b/docs/en/compare/yolov8-vs-yolox.md
@@ -33,7 +33,7 @@ Introduced by Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, and Jian Sun from Meg
 
 While highly influential in 2021, the [YOLOX GitHub repository](https://github.com/Megvii-BaseDetection/YOLOX) remains a primarily research-focused codebase. It lacks the extensive task versatility and polished deployment pipelines found in modern frameworks, requiring more manual configuration for production deployment.
 
-[View the YOLOX Documentation](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[View the YOLOX Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 ## Architectural Innovations
 

--- a/docs/en/compare/yolov9-vs-damo-yolo.md
+++ b/docs/en/compare/yolov9-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs DAMO-YOLO Comparison
 comments: true
 description: Compare YOLOv9 and DAMO-YOLO. Discover their architecture, performance, strengths, and use cases to find the best fit for your object detection needs.
 keywords: YOLOv9, DAMO-YOLO, object detection, neural networks, AI comparison, real-time detection, model efficiency, computer vision, YOLO comparison, Ultralytics

--- a/docs/en/compare/yolov9-vs-damo-yolo.md
+++ b/docs/en/compare/yolov9-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and DAMO-YOLO. Discover their architecture, performa
 keywords: YOLOv9, DAMO-YOLO, object detection, neural networks, AI comparison, real-time detection, model efficiency, computer vision, YOLO comparison, Ultralytics
 ---
 
-# YOLOv9 vs. DAMO-YOLO: A Technical Comparison of Object Detection Models
+# YOLOv9 vs DAMO-YOLO
 
 The rapid evolution of computer vision has produced an array of powerful architectures tailored for varying deployment constraints and accuracy requirements. Two notable entries in this space are **YOLOv9**, celebrated for its robust handling of information bottlenecks, and **DAMO-YOLO**, which focuses heavily on Neural Architecture Search (NAS) and efficient feature pyramids.
 

--- a/docs/en/compare/yolov9-vs-efficientdet.md
+++ b/docs/en/compare/yolov9-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Discover detailed insights comparing YOLOv9 and EfficientDet for ob
 keywords: YOLOv9,EfficientDet,object detection,model comparison,YOLO,EfficientDet models,deep learning,computer vision,benchmarking,Ultralytics
 ---
 
-# YOLOv9 vs. EfficientDet: A Comprehensive Technical Comparison of Object Detection Architectures
+# YOLOv9 vs EfficientDet
 
 The field of computer vision has witnessed a rapid evolution in real-time [object detection](https://docs.ultralytics.com/tasks/detect), with researchers continuously pushing the boundaries of accuracy and efficiency. When building robust vision systems, selecting the optimal architecture is a critical decision. Two highly discussed models in this space are **YOLOv9**, an advanced iteration of the YOLO lineage focusing on gradient information, and **EfficientDet**, a scalable framework developed by Google.
 

--- a/docs/en/compare/yolov9-vs-efficientdet.md
+++ b/docs/en/compare/yolov9-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs EfficientDet Comparison
 comments: true
 description: Discover detailed insights comparing YOLOv9 and EfficientDet for object detection. Learn about their performance, architecture, and best use cases.
 keywords: YOLOv9,EfficientDet,object detection,model comparison,YOLO,EfficientDet models,deep learning,computer vision,benchmarking,Ultralytics

--- a/docs/en/compare/yolov9-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov9-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and PP-YOLOE+ models in architecture, performance, a
 keywords: YOLOv9,PP-YOLOE+,object detection,model comparison,computer vision,AI,deep learning,YOLO,PP-YOLOE,performance comparison
 ---
 
-# YOLOv9 vs. PP-YOLOE+: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs PP-YOLOE+
 
 The landscape of real-time object detection continues to advance rapidly, offering computer vision engineers a wide array of choices for deploying highly accurate models on edge and cloud infrastructure. Two prominent models in this space are **[YOLOv9](https://docs.ultralytics.com/models/yolov9)** and **PP-YOLOE+**. While both push the boundaries of accuracy and speed, they emerge from different research lineages and software ecosystems.
 

--- a/docs/en/compare/yolov9-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov9-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLOv9 and PP-YOLOE+ models in architecture, performance, and use cases. Find the best object detection model for your needs.
 keywords: YOLOv9,PP-YOLOE+,object detection,model comparison,computer vision,AI,deep learning,YOLO,PP-YOLOE,performance comparison

--- a/docs/en/compare/yolov9-vs-rtdetr.md
+++ b/docs/en/compare/yolov9-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and RTDETRv2 for object detection. Explore speed, ac
 keywords: YOLOv9, RTDETRv2, object detection, model comparison, AI models, computer vision, YOLO, real-time detection, transformers, efficiency
 ---
 
-# YOLOv9 vs. RTDETRv2: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs RTDETRv2
 
 The landscape of real-time [object detection](https://docs.ultralytics.com/tasks/detect) has experienced a paradigm shift in recent years. Two distinct architectural philosophies have emerged to dominate the field: highly optimized Convolutional Neural Networks (CNNs) and real-time Detection Transformers (DETRs). Representing the pinnacle of these two approaches are **YOLOv9** and **RTDETRv2**.
 

--- a/docs/en/compare/yolov9-vs-rtdetr.md
+++ b/docs/en/compare/yolov9-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs RTDETRv2 Comparison
 comments: true
 description: Compare YOLOv9 and RTDETRv2 for object detection. Explore speed, accuracy, use cases, and architectures to choose the best for your project.
 keywords: YOLOv9, RTDETRv2, object detection, model comparison, AI models, computer vision, YOLO, real-time detection, transformers, efficiency

--- a/docs/en/compare/yolov9-vs-yolo11.md
+++ b/docs/en/compare/yolov9-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLO11 Comparison
 comments: true
 description: Compare YOLO11 and YOLOv9 for object detection. Explore innovations, benchmarks, and use cases to select the best model for your tasks.
 keywords: YOLO11, YOLOv9, object detection, model comparison, benchmarks, Ultralytics, real-time processing, machine learning, computer vision

--- a/docs/en/compare/yolov9-vs-yolo11.md
+++ b/docs/en/compare/yolov9-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and YOLOv9 for object detection. Explore innovations
 keywords: YOLO11, YOLOv9, object detection, model comparison, benchmarks, Ultralytics, real-time processing, machine learning, computer vision
 ---
 
-# YOLOv9 vs. YOLO11: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLO11
 
 The rapid evolution of computer vision has continuously pushed the boundaries of what is possible in real-time [object detection](https://docs.ultralytics.com/tasks/detect). When comparing leading architectures, **YOLOv9** and **[Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11)** stand out as monumental leaps forward, each serving distinct technical needs. YOLOv9 introduced novel ways to preserve gradient flow during deep network training, while YOLO11 revolutionized the general-purpose vision ecosystem with unmatched efficiency, versatility, and ease of use.
 

--- a/docs/en/compare/yolov9-vs-yolo26.md
+++ b/docs/en/compare/yolov9-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLO26 Comparison
 comments: true
 description: Compare YOLOv9 and YOLO26 for object detection. Explore performance, architecture, and ideal use cases to choose the best model for your needs.
 keywords: YOLOv9, YOLO26, object detection, model comparison, real-time detection, computer vision, edge devices, accuracy, performance metrics

--- a/docs/en/compare/yolov9-vs-yolo26.md
+++ b/docs/en/compare/yolov9-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and YOLO26 for object detection. Explore performance
 keywords: YOLOv9, YOLO26, object detection, model comparison, real-time detection, computer vision, edge devices, accuracy, performance metrics
 ---
 
-# YOLOv9 vs. YOLO26: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLO26
 
 The landscape of real-time [object detection](https://en.wikipedia.org/wiki/Object_detection) has evolved significantly over the past few years. As machine learning practitioners look to deploy models across a variety of hardware, choosing the right architecture is critical. In this comprehensive technical guide, we compare two major milestones in the computer vision field: [YOLOv9](https://arxiv.org/abs/2402.13616), introduced in early 2024 with a focus on gradient path optimizations, and **[Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26)**, the latest state-of-the-art framework released in early 2026 that completely redefines edge inference and training stability.
 

--- a/docs/en/compare/yolov9-vs-yolov10.md
+++ b/docs/en/compare/yolov9-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLOv9 and YOLOv10, cove
 keywords: YOLOv9, YOLOv10, object detection, Ultralytics, computer vision, model comparison, AI models, deep learning, efficiency, accuracy, real-time
 ---
 
-# YOLOv9 vs YOLOv10: A Technical Deep Dive into Real-Time Object Detection Evolution
+# YOLOv9 vs YOLOv10
 
 The landscape of real-time computer vision has seen immense advancements, driven largely by researchers continuously pushing the performance-efficiency boundary. When analyzing the evolution of state-of-the-art vision models, **YOLOv9** and **YOLOv10** represent two critical milestones. Released in early 2024, both models introduced paradigm-shifting architectural designs to address long-standing challenges in deep neural networks, from information bottlenecks to post-processing latency.
 

--- a/docs/en/compare/yolov9-vs-yolov10.md
+++ b/docs/en/compare/yolov9-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOv10 Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLOv9 and YOLOv10, covering architecture, performance, and use cases. Find the best model for your needs.
 keywords: YOLOv9, YOLOv10, object detection, Ultralytics, computer vision, model comparison, AI models, deep learning, efficiency, accuracy, real-time

--- a/docs/en/compare/yolov9-vs-yolov5.md
+++ b/docs/en/compare/yolov9-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOv5 Comparison
 comments: true
 description: Compare YOLOv9 and YOLOv5 models for object detection. Explore their architecture, performance, use cases, and key differences to choose the best fit.
 keywords: YOLOv9 vs YOLOv5, YOLO comparison, Ultralytics models, YOLO object detection, YOLO performance, real-time detection, model differences, computer vision

--- a/docs/en/compare/yolov9-vs-yolov5.md
+++ b/docs/en/compare/yolov9-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and YOLOv5 models for object detection. Explore thei
 keywords: YOLOv9 vs YOLOv5, YOLO comparison, Ultralytics models, YOLO object detection, YOLO performance, real-time detection, model differences, computer vision
 ---
 
-# YOLOv9 vs YOLOv5: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLOv5
 
 The field of computer vision has witnessed tremendous growth, with object detection acting as the backbone for countless industrial and research applications. Choosing the right architecture often requires a careful evaluation of mean Average Precision (mAP), inference speed, and memory overhead. In this comparison, we explore two highly influential models: **YOLOv9**, celebrated for its architectural breakthroughs in gradient information retention, and **[Ultralytics YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5)**, the battle-tested industry standard known for its incredible ease of use and unmatched deployment versatility.
 

--- a/docs/en/compare/yolov9-vs-yolov6.md
+++ b/docs/en/compare/yolov9-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and YOLOv6-3.0 in architecture, performance, and app
 keywords: YOLOv9, YOLOv6-3.0, object detection, model comparison, deep learning, computer vision, performance benchmarks, real-time AI, efficient algorithms, Ultralytics documentation
 ---
 
-# YOLOv9 vs YOLOv6-3.0: A Comprehensive Technical Comparison
+# YOLOv9 vs YOLOv6-3.0
 
 The evolution of real-time object detection has been driven by continuous innovations in neural network architectures, optimizing the delicate balance between inference speed, accuracy, and computational efficiency. As developers and researchers navigate the crowded landscape of computer vision frameworks, comparing leading architectures is essential for selecting the right tool for the job.
 

--- a/docs/en/compare/yolov9-vs-yolov6.md
+++ b/docs/en/compare/yolov9-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOv6-3.0 Comparison
 comments: true
 description: Compare YOLOv9 and YOLOv6-3.0 in architecture, performance, and applications. Discover the ideal model for your object detection needs.
 keywords: YOLOv9, YOLOv6-3.0, object detection, model comparison, deep learning, computer vision, performance benchmarks, real-time AI, efficient algorithms, Ultralytics documentation

--- a/docs/en/compare/yolov9-vs-yolov7.md
+++ b/docs/en/compare/yolov9-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOv7 Comparison
 comments: true
 description: Compare YOLOv9 and YOLOv7 for object detection. Explore their performance, architecture differences, strengths, and ideal applications.
 keywords: YOLOv9, YOLOv7, object detection, AI models, technical comparison, neural networks, deep learning, Ultralytics, real-time detection, performance metrics

--- a/docs/en/compare/yolov9-vs-yolov7.md
+++ b/docs/en/compare/yolov9-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Compare YOLOv9 and YOLOv7 for object detection. Explore their perfo
 keywords: YOLOv9, YOLOv7, object detection, AI models, technical comparison, neural networks, deep learning, Ultralytics, real-time detection, performance metrics
 ---
 
-# YOLOv9 vs YOLOv7: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLOv7
 
 The evolution of real-time [object detection](https://en.wikipedia.org/wiki/Object_detection) has been driven by a continuous quest to balance computational efficiency with high accuracy. Two landmark architectures in this journey are YOLOv9 and YOLOv7, both developed by researchers at the Institute of Information Science, Academia Sinica in Taiwan. While YOLOv7 introduced revolutionary trainable bag-of-freebies, the newer YOLOv9 tackles deep learning information bottlenecks head-on.
 

--- a/docs/en/compare/yolov9-vs-yolov8.md
+++ b/docs/en/compare/yolov9-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Discover the detailed technical comparison of YOLOv9 and YOLOv8. Ex
 keywords: YOLOv9, YOLOv8, object detection, computer vision, YOLO comparison, deep learning, machine learning, Ultralytics models, AI models, real-time detection
 ---
 
-# YOLOv9 vs. YOLOv8: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLOv8
 
 The landscape of real-time computer vision has evolved remarkably over the last few years, with each new model pushing the theoretical boundaries of what is possible on edge devices and cloud servers alike. When comparing the newer [YOLOv9 architecture](https://docs.ultralytics.com/models/yolov9) to the highly popular [Ultralytics YOLOv8](https://platform.ultralytics.com/ultralytics/yolov8) framework, developers are often faced with a choice between cutting-edge theoretical gradient paths and a heavily battle-tested, production-ready ecosystem.
 

--- a/docs/en/compare/yolov9-vs-yolov8.md
+++ b/docs/en/compare/yolov9-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOv8 Comparison
 comments: true
 description: Discover the detailed technical comparison of YOLOv9 and YOLOv8. Explore their strengths, weaknesses, efficiency, and ideal use cases for object detection.
 keywords: YOLOv9, YOLOv8, object detection, computer vision, YOLO comparison, deep learning, machine learning, Ultralytics models, AI models, real-time detection

--- a/docs/en/compare/yolov9-vs-yolox.md
+++ b/docs/en/compare/yolov9-vs-yolox.md
@@ -4,7 +4,7 @@ description: Discover a detailed comparison of YOLOv9 and YOLOX, covering archit
 keywords: YOLOv9, YOLOX, object detection, model comparison, computer vision, YOLO models, architecture, benchmarks, deep learning
 ---
 
-# YOLOv9 vs YOLOX: A Technical Deep Dive into Modern Object Detection
+# YOLOv9 vs YOLOX
 
 The field of computer vision has witnessed a rapid evolution in real-time object detection architectures. This guide provides a comprehensive comparison between **[YOLOv9](https://docs.ultralytics.com/models/yolov9)** and **YOLOX**, analyzing their architectural innovations, performance metrics, and training methodologies. Whether you are building smart applications for [AI in manufacturing](https://www.ultralytics.com/solutions/ai-in-manufacturing) or exploring [predictive modeling](https://www.ultralytics.com/glossary/predictive-modeling), understanding these models will help you make informed decisions for your next deployment.
 

--- a/docs/en/compare/yolov9-vs-yolox.md
+++ b/docs/en/compare/yolov9-vs-yolox.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 vs YOLOX Comparison
 comments: true
 description: Discover a detailed comparison of YOLOv9 and YOLOX, covering architectures, benchmarks, and use cases to help you choose the best object detection model.
 keywords: YOLOv9, YOLOX, object detection, model comparison, computer vision, YOLO models, architecture, benchmarks, deep learning

--- a/docs/en/compare/yolox-vs-damo-yolo.md
+++ b/docs/en/compare/yolox-vs-damo-yolo.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and DAMO-YOLO object detection models. Explore archit
 keywords: YOLOX, DAMO-YOLO, object detection, model comparison, YOLO models, deep learning, computer vision, machine learning, AI, real-time detection
 ---
 
-# YOLOX vs DAMO-YOLO: Comparing Anchor-Free and NAS-Driven Object Detectors
+# YOLOX vs DAMO-YOLO
 
 The evolution of real-time object detection has seen numerous paradigms shift, from anchor-based to anchor-free architectures, and from manually designed backbones to automated neural architecture search (NAS). In this comprehensive technical comparison, we will analyze two significant milestones in this journey: **YOLOX** and **DAMO-YOLO**. We will explore their architectural innovations, training methodologies, and performance trade-offs, while also highlighting how the modern [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) provides an unparalleled alternative for modern developers.
 

--- a/docs/en/compare/yolox-vs-damo-yolo.md
+++ b/docs/en/compare/yolox-vs-damo-yolo.md
@@ -29,7 +29,7 @@ YOLOX introduced several core structural shifts that drastically improved upon i
 
     YOLOX's decoupled head design heavily influenced subsequent generations of object detectors, becoming a standard feature in many modern models.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 ## DAMO-YOLO: Automated Architecture Search at Scale
 

--- a/docs/en/compare/yolox-vs-damo-yolo.md
+++ b/docs/en/compare/yolox-vs-damo-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs DAMO-YOLO Comparison
 comments: true
 description: Compare YOLOX and DAMO-YOLO object detection models. Explore architecture, performance, use cases, and choose the best fit for your project.
 keywords: YOLOX, DAMO-YOLO, object detection, model comparison, YOLO models, deep learning, computer vision, machine learning, AI, real-time detection

--- a/docs/en/compare/yolox-vs-efficientdet.md
+++ b/docs/en/compare/yolox-vs-efficientdet.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and EfficientDet for object detection. Explore archit
 keywords: YOLOX, EfficientDet, object detection, model comparison, deep learning, computer vision, performance benchmark, Ultralytics
 ---
 
-# YOLOX vs. EfficientDet: Evaluating Anchor-Free and Scalable Object Detection
+# YOLOX vs EfficientDet
 
 The evolution of [object detection](https://docs.ultralytics.com/tasks/detect) has been driven by the constant pursuit of balancing speed, accuracy, and computational efficiency. Two landmark models that significantly influenced this trajectory are YOLOX and EfficientDet. While YOLOX introduced a highly optimized anchor-free design to the YOLO family, EfficientDet focused on a scalable architecture utilizing compound scaling and BiFPN. This guide provides a detailed technical comparison of their architectures, performance metrics, and training methodologies, while also introducing modern alternatives like the cutting-edge [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26) model.
 

--- a/docs/en/compare/yolox-vs-efficientdet.md
+++ b/docs/en/compare/yolox-vs-efficientdet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs EfficientDet Comparison
 comments: true
 description: Compare YOLOX and EfficientDet for object detection. Explore architecture, performance, and use cases to pick the best model for your needs.
 keywords: YOLOX, EfficientDet, object detection, model comparison, deep learning, computer vision, performance benchmark, Ultralytics

--- a/docs/en/compare/yolox-vs-efficientdet.md
+++ b/docs/en/compare/yolox-vs-efficientdet.md
@@ -19,9 +19,9 @@ Before diving into their structural differences, it is important to understand t
 - **Date:** July 18, 2021
 - **ArXiv:** [YOLOX: Exceeding YOLO Series in 2021](https://arxiv.org/abs/2107.08430)
 - **GitHub:** [Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Documentation:** [YOLOX Official Docs](https://yolox.readthedocs.io/en/latest/)
+- **Documentation:** [YOLOX Official Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 **EfficientDet Details:**
 

--- a/docs/en/compare/yolox-vs-pp-yoloe.md
+++ b/docs/en/compare/yolox-vs-pp-yoloe.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs PP-YOLOE+ Comparison
 comments: true
 description: Compare YOLOX and PP-YOLOE+, two anchor-free object detection models. Explore performance, architecture, and use cases to choose the best fit.
 keywords: YOLOX,PP-YOLOE,object detection,anchor-free models,AI comparison,YOLO models,computer vision,performance metrics,YOLOX features,PP-YOLOE+ use cases

--- a/docs/en/compare/yolox-vs-pp-yoloe.md
+++ b/docs/en/compare/yolox-vs-pp-yoloe.md
@@ -23,7 +23,7 @@ Developed by Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, and Jian Sun at [Megvi
 
 YOLOX integrates a decoupled head, separating classification and regression tasks, which significantly improves convergence speed during training. Additionally, it introduced advanced label assignment strategies like SimOTA to dynamically assign positive samples. This makes the model highly efficient, especially in [edge AI](https://www.ultralytics.com/glossary/edge-ai) environments where computational resources are strictly limited.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 ### PP-YOLOE+: High-Performance Industrial Detection
 

--- a/docs/en/compare/yolox-vs-pp-yoloe.md
+++ b/docs/en/compare/yolox-vs-pp-yoloe.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and PP-YOLOE+, two anchor-free object detection model
 keywords: YOLOX,PP-YOLOE,object detection,anchor-free models,AI comparison,YOLO models,computer vision,performance metrics,YOLOX features,PP-YOLOE+ use cases
 ---
 
-# YOLOX vs. PP-YOLOE+: A Comprehensive Technical Comparison
+# YOLOX vs PP-YOLOE+
 
 When designing a robust [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipeline, selecting the appropriate object detection model is a critical decision. The landscape of real-time object detectors is highly competitive, with numerous architectures striving to offer the ultimate balance between inference speed and detection accuracy. In this technical comparison, we will evaluate two prominent models: YOLOX and PP-YOLOE+. By examining their architectural designs, training methodologies, and performance metrics, we aim to provide developers and researchers with the insights needed to choose the right tool for their deployment environments.
 

--- a/docs/en/compare/yolox-vs-rtdetr.md
+++ b/docs/en/compare/yolox-vs-rtdetr.md
@@ -4,7 +4,7 @@ description: Discover the key differences between YOLOX and RTDETRv2. Compare pe
 keywords: YOLOX, RTDETRv2, object detection, YOLOX vs RTDETRv2, performance comparison, Ultralytics, machine learning, computer vision, object detection models
 ---
 
-# YOLOX vs. RTDETRv2: Evaluating the Evolution of Real-Time Object Detection Models
+# YOLOX vs RTDETRv2
 
 Choosing the optimal architecture for [computer vision applications](https://www.ultralytics.com/glossary/computer-vision-cv) requires a careful balance of accuracy, inference speed, and deployment feasibility. In this comprehensive technical analysis, we explore the fundamental differences between **YOLOX**, a highly successful anchor-free CNN architecture, and **RTDETRv2**, a state-of-the-art real-time detection transformer.
 

--- a/docs/en/compare/yolox-vs-rtdetr.md
+++ b/docs/en/compare/yolox-vs-rtdetr.md
@@ -22,7 +22,7 @@ YOLOX emerged as a highly popular anchor-free adaptation of the YOLO series, int
 - **Authors:** Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, and Jian Sun
 - **Organization:** [Megvii](https://en.megvii.com/)
 - **Date:** July 18, 2021
-- **Links:** [Arxiv](https://arxiv.org/abs/2107.08430), [GitHub](https://github.com/Megvii-BaseDetection/YOLOX), [Docs](https://yolox.readthedocs.io/en/latest/)
+- **Links:** [Arxiv](https://arxiv.org/abs/2107.08430), [GitHub](https://github.com/Megvii-BaseDetection/YOLOX), [Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architectural Innovations
 

--- a/docs/en/compare/yolox-vs-rtdetr.md
+++ b/docs/en/compare/yolox-vs-rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs RTDETRv2 Comparison
 comments: true
 description: Discover the key differences between YOLOX and RTDETRv2. Compare performance, architecture, and use cases for optimal object detection model selection.
 keywords: YOLOX, RTDETRv2, object detection, YOLOX vs RTDETRv2, performance comparison, Ultralytics, machine learning, computer vision, object detection models

--- a/docs/en/compare/yolox-vs-yolo11.md
+++ b/docs/en/compare/yolox-vs-yolo11.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLO11 Comparison
 comments: true
 description: Compare YOLO11 and YOLOX for object detection. Explore benchmarks, architectures, and use cases to choose the best model for your project.
 keywords: YOLO11, YOLOX, object detection, model comparison, computer vision, real-time detection, deep learning, architecture comparison, Ultralytics, AI models

--- a/docs/en/compare/yolox-vs-yolo11.md
+++ b/docs/en/compare/yolox-vs-yolo11.md
@@ -4,7 +4,7 @@ description: Compare YOLO11 and YOLOX for object detection. Explore benchmarks, 
 keywords: YOLO11, YOLOX, object detection, model comparison, computer vision, real-time detection, deep learning, architecture comparison, Ultralytics, AI models
 ---
 
-# YOLOX vs YOLO11: A Deep Dive into High-Performance Object Detection
+# YOLOX vs YOLO11
 
 The evolution of computer vision has been heavily driven by the pursuit of real-time object detection frameworks that balance high accuracy with inference speed. Among the most notable milestones in this journey are [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) and [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11). While both models have made significant contributions to the field, their underlying architectures, design philosophies, and developer ecosystems differ substantially.
 

--- a/docs/en/compare/yolox-vs-yolo11.md
+++ b/docs/en/compare/yolox-vs-yolo11.md
@@ -27,7 +27,7 @@ YOLOX departed from traditional anchor-based detection by adopting a decoupled h
 
 While YOLOX offers excellent accuracy for its time, it primarily focuses on bounding box object detection and lacks native support for other complex vision tasks out of the box.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 !!! note "Anchor-Free Design"
 

--- a/docs/en/compare/yolox-vs-yolo26.md
+++ b/docs/en/compare/yolox-vs-yolo26.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and YOLO26 for object detection. Explore architecture
 keywords: YOLOX, YOLO26, object detection, model comparison, performance metrics, computer vision, YOLO, anchor-free, NMS-free, COCO dataset
 ---
 
-# YOLOX vs YOLO26: The Evolution from Anchor-Free to End-to-End Object Detection
+# YOLOX vs YOLO26
 
 The field of computer vision has witnessed incredible transformations over the past decade. Two significant milestones in this journey are the release of YOLOX, which popularized anchor-free architectures, and the recent introduction of [Ultralytics YOLO26](https://platform.ultralytics.com/ultralytics/yolo26), which completely redefines real-time performance with a natively end-to-end, NMS-free design. This comprehensive comparison explores their architectures, performance metrics, and ideal deployment scenarios to help developers make informed decisions for their next AI project.
 

--- a/docs/en/compare/yolox-vs-yolo26.md
+++ b/docs/en/compare/yolox-vs-yolo26.md
@@ -24,7 +24,7 @@ Organization: [Megvii](https://en.megvii.com/)
 Date: 2021-07-18  
 Arxiv: [2107.08430](https://arxiv.org/abs/2107.08430)  
 GitHub: [Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)  
-Docs: [YOLOX ReadTheDocs](https://yolox.readthedocs.io/en/latest/)
+Docs: [YOLOX GitHub Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 Introduced in mid-2021, YOLOX represented a major shift by adopting an anchor-free design coupled with a decoupled head and the advanced label assignment strategy known as SimOTA. By stepping away from the traditional anchor box mechanisms that dominated previous architectures, YOLOX successfully bridged the gap between academic research and industrial application, offering an elegant yet highly effective framework for [object detection](https://docs.ultralytics.com/tasks/detect).
 

--- a/docs/en/compare/yolox-vs-yolo26.md
+++ b/docs/en/compare/yolox-vs-yolo26.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLO26 Comparison
 comments: true
 description: Compare YOLOX and YOLO26 for object detection. Explore architectures, metrics, and use cases to select the right model for your needs.
 keywords: YOLOX, YOLO26, object detection, model comparison, performance metrics, computer vision, YOLO, anchor-free, NMS-free, COCO dataset

--- a/docs/en/compare/yolox-vs-yolov10.md
+++ b/docs/en/compare/yolox-vs-yolov10.md
@@ -4,7 +4,7 @@ description: Compare YOLOv10 and YOLOX for object detection. Explore architectur
 keywords: YOLOv10, YOLOX, object detection, Ultralytics, real-time, model comparison, benchmark, computer vision, deep learning, AI
 ---
 
-# YOLOX vs YOLOv10: Comparing Anchor-Free and NMS-Free Real-Time Object Detection
+# YOLOX vs YOLOv10
 
 The evolution of real-time computer vision models has been marked by significant architectural leaps. Two pivotal milestones in this journey are YOLOX and YOLOv10. Released in 2021, YOLOX successfully bridged the gap between academic research and industrial application by introducing a highly effective anchor-free design. Three years later, YOLOv10 revolutionized the field by eliminating the need for Non-Maximum Suppression (NMS) during post-processing, pushing the boundaries of efficiency and speed.
 

--- a/docs/en/compare/yolox-vs-yolov10.md
+++ b/docs/en/compare/yolox-vs-yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv10 Comparison
 comments: true
 description: Compare YOLOv10 and YOLOX for object detection. Explore architecture, benchmarks, and use cases to choose the best real-time detection model for your needs.
 keywords: YOLOv10, YOLOX, object detection, Ultralytics, real-time, model comparison, benchmark, computer vision, deep learning, AI

--- a/docs/en/compare/yolox-vs-yolov10.md
+++ b/docs/en/compare/yolox-vs-yolov10.md
@@ -25,7 +25,7 @@ Organization: [Megvii](https://en.megvii.com/)
 Date: 2021-07-18  
 Arxiv: [https://arxiv.org/abs/2107.08430](https://arxiv.org/abs/2107.08430)  
 GitHub: [https://github.com/Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)  
-Docs: [https://yolox.readthedocs.io/en/latest/](https://yolox.readthedocs.io/en/latest/)
+Docs: [https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 [Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX){ .md-button }
 

--- a/docs/en/compare/yolox-vs-yolov5.md
+++ b/docs/en/compare/yolox-vs-yolov5.md
@@ -21,7 +21,7 @@ Both models emerged during a period of rapid advancement in real-time object det
 
 Released by researchers Zheng Ge, Songtao Liu, Feng Wang, Zeming Li, and Jian Sun at [Megvii](https://en.megvii.com/) on July 18, 2021, YOLOX introduced a significant shift by moving away from traditional anchor boxes. Documented in their [Arxiv technical report](https://arxiv.org/abs/2107.08430), YOLOX integrated an anchor-free design with a decoupled head and the SimOTA label assignment strategy. This design aimed to bridge the gap between academic research and industrial application, offering strong performance on standard datasets.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 ### YOLOv5: The Standard for Production Vision AI
 

--- a/docs/en/compare/yolox-vs-yolov5.md
+++ b/docs/en/compare/yolox-vs-yolov5.md
@@ -4,7 +4,7 @@ description: Explore a detailed technical comparison of YOLOX vs YOLOv5. Learn t
 keywords: YOLOX, YOLOv5, object detection, anchor-free model, real-time detection, computer vision, Ultralytics, model comparison, AI benchmark
 ---
 
-# YOLOX vs. YOLOv5: In-Depth Architecture and Performance Comparison
+# YOLOX vs YOLOv5
 
 Selecting the right object detection model is a critical decision that dictates the success of any computer vision project. This guide provides a comprehensive technical comparison between two pivotal models in the AI landscape: Megvii's YOLOX and [Ultralytics YOLOv5](https://platform.ultralytics.com/ultralytics/yolov5). By analyzing their architectures, performance metrics, and training ecosystems, we aim to help developers and researchers make an informed choice for their specific deployment environments.
 

--- a/docs/en/compare/yolox-vs-yolov5.md
+++ b/docs/en/compare/yolox-vs-yolov5.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv5 Comparison
 comments: true
 description: Explore a detailed technical comparison of YOLOX vs YOLOv5. Learn their differences in architecture, performance, and ideal applications for object detection.
 keywords: YOLOX, YOLOv5, object detection, anchor-free model, real-time detection, computer vision, Ultralytics, model comparison, AI benchmark

--- a/docs/en/compare/yolox-vs-yolov6.md
+++ b/docs/en/compare/yolox-vs-yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv6-3.0 Comparison
 comments: true
 description: Compare YOLOX and YOLOv6-3.0 for object detection. Learn about architecture, performance, and applications to choose the best model for your needs.
 keywords: YOLOX, YOLOv6-3.0, object detection, model comparison, performance benchmarks, real-time detection, machine learning, computer vision

--- a/docs/en/compare/yolox-vs-yolov6.md
+++ b/docs/en/compare/yolox-vs-yolov6.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and YOLOv6-3.0 for object detection. Learn about arch
 keywords: YOLOX, YOLOv6-3.0, object detection, model comparison, performance benchmarks, real-time detection, machine learning, computer vision
 ---
 
-# YOLOX vs. YOLOv6-3.0: A Comprehensive Guide to Anchor-Free and Industrial Object Detection
+# YOLOX vs YOLOv6-3.0
 
 The evolution of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) has been largely defined by the rapid advancements in the YOLO series. Choosing the right architecture for your deployment often comes down to balancing raw throughput, architectural simplicity, and training efficiency. Two notable milestones in this journey are the anchor-free research focus of YOLOX and the highly optimized industrial throughput of YOLOv6-3.0.
 

--- a/docs/en/compare/yolox-vs-yolov7.md
+++ b/docs/en/compare/yolox-vs-yolov7.md
@@ -4,7 +4,7 @@ description: Discover the differences between YOLOX and YOLOv7, two top computer
 keywords: YOLOX, YOLOv7, object detection, computer vision, model comparison, anchor-free, YOLO models, machine learning, AI performance
 ---
 
-# YOLOX vs YOLOv7: A Comprehensive Technical Comparison
+# YOLOX vs YOLOv7
 
 The evolution of real-time [object detection](https://docs.ultralytics.com/tasks/detect) has been driven by continuous architectural breakthroughs. Two significant milestones in this journey are **YOLOX** and **YOLOv7**. Released within a year of each other, both models introduced novel approaches to the standard object detection paradigm, significantly improving the trade-off between speed and [accuracy](https://www.ultralytics.com/glossary/accuracy).
 

--- a/docs/en/compare/yolox-vs-yolov7.md
+++ b/docs/en/compare/yolox-vs-yolov7.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv7 Comparison
 comments: true
 description: Discover the differences between YOLOX and YOLOv7, two top computer vision models. Learn about their architecture, performance, and ideal use cases.
 keywords: YOLOX, YOLOv7, object detection, computer vision, model comparison, anchor-free, YOLO models, machine learning, AI performance

--- a/docs/en/compare/yolox-vs-yolov7.md
+++ b/docs/en/compare/yolox-vs-yolov7.md
@@ -26,13 +26,13 @@ Introduced by researchers at Megvii in July 2021, YOLOX represented a major shif
 - **Date:** 2021-07-18
 - **Research Paper:** [arXiv:2107.08430](https://arxiv.org/abs/2107.08430)
 - **Source Code:** [Megvii YOLOX GitHub](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Documentation:** [YOLOX ReadTheDocs](https://yolox.readthedocs.io/en/latest/)
+- **Documentation:** [YOLOX GitHub Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architectural Innovations
 
 YOLOX introduced an **anchor-free** approach, which drastically reduced the number of design parameters and heuristic tweaking required for custom datasets. It implemented a decoupled head, separating the classification and regression tasks, which improved convergence speed and accuracy. Additionally, YOLOX utilized advanced [data augmentation](https://www.ultralytics.com/glossary/data-augmentation) strategies like MixUp and Mosaic to enhance model robustness.
 
-[Learn more about YOLOX](https://yolox.readthedocs.io/en/latest/){ .md-button }
+[Learn more about YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs){ .md-button }
 
 !!! note "Anchor-Free Advantage"
 

--- a/docs/en/compare/yolox-vs-yolov8.md
+++ b/docs/en/compare/yolox-vs-yolov8.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv8 Comparison
 comments: true
 description: Compare YOLOX and YOLOv8 for object detection. Explore their strengths, weaknesses, and benchmarks to make the best model choice for your needs.
 keywords: YOLOX, YOLOv8, object detection, model comparison, YOLO models, computer vision, machine learning, performance benchmarks, YOLO architecture

--- a/docs/en/compare/yolox-vs-yolov8.md
+++ b/docs/en/compare/yolox-vs-yolov8.md
@@ -25,7 +25,7 @@ Organization: [Megvii](https://en.megvii.com/)
 Date: 2021-07-18  
 Arxiv: [YOLOX: Exceeding YOLO Series in 2021](https://arxiv.org/abs/2107.08430)  
 GitHub: [Megvii-BaseDetection/YOLOX](https://github.com/Megvii-BaseDetection/YOLOX)  
-Docs: [YOLOX Documentation](https://yolox.readthedocs.io/en/latest/)
+Docs: [YOLOX Documentation](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architectural Highlights
 

--- a/docs/en/compare/yolox-vs-yolov8.md
+++ b/docs/en/compare/yolox-vs-yolov8.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and YOLOv8 for object detection. Explore their streng
 keywords: YOLOX, YOLOv8, object detection, model comparison, YOLO models, computer vision, machine learning, performance benchmarks, YOLO architecture
 ---
 
-# YOLOX vs YOLOv8: Comprehensive Architectural and Performance Comparison
+# YOLOX vs YOLOv8
 
 The field of computer vision has witnessed remarkable advancements in real-time object detection over the past few years. As researchers and engineers continuously push the boundaries of accuracy and speed, navigating the landscape of available models can be challenging. This comprehensive guide provides an in-depth technical comparison between two highly influential architectures: YOLOX and Ultralytics YOLOv8.
 

--- a/docs/en/compare/yolox-vs-yolov9.md
+++ b/docs/en/compare/yolox-vs-yolov9.md
@@ -24,7 +24,7 @@ Released in mid-2021, YOLOX was a major step forward in bridging the gap between
 - **Release Date:** July 18, 2021
 - **Reference:** [Arxiv Paper](https://arxiv.org/abs/2107.08430)
 - **Source Code:** [YOLOX GitHub Repository](https://github.com/Megvii-BaseDetection/YOLOX)
-- **Documentation:** [YOLOX Official Docs](https://yolox.readthedocs.io/en/latest/)
+- **Documentation:** [YOLOX Official Docs](https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs)
 
 ### Architectural Innovations
 

--- a/docs/en/compare/yolox-vs-yolov9.md
+++ b/docs/en/compare/yolox-vs-yolov9.md
@@ -4,7 +4,7 @@ description: Compare YOLOX and YOLOv9 for object detection. Explore performance,
 keywords: YOLOX, YOLOv9, object detection, model comparison, computer vision, AI models, deep learning, performance benchmarks, architecture, real-time detection
 ---
 
-# YOLOX vs. YOLOv9: Comparing Anchor-Free Designs to Programmable Gradients
+# YOLOX vs YOLOv9
 
 The landscape of computer vision has been shaped by continuous architectural breakthroughs that balance computational efficiency with high precision. When evaluating real-time object detection models, the comparison between Megvii's YOLOX and Academia Sinica's YOLOv9 highlights two distinct philosophies in deep learning development. While one pioneered a simplified anchor-free paradigm, the other introduced advanced gradient routing techniques to maximize information retention.
 

--- a/docs/en/compare/yolox-vs-yolov9.md
+++ b/docs/en/compare/yolox-vs-yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOX vs YOLOv9 Comparison
 comments: true
 description: Compare YOLOX and YOLOv9 for object detection. Explore performance, architecture, and use cases to choose the best model for your vision tasks.
 keywords: YOLOX, YOLOv9, object detection, model comparison, computer vision, AI models, deep learning, performance benchmarks, architecture, real-time detection


### PR DESCRIPTION
## Summary
- shorten compare page H1s so generated title tags stay within SEO length limits
- replace YOLOX ReadTheDocs links with the official YOLOX GitHub docs source

## Validation
- checked 157 compare pages have title tags at or under 45 characters including ` | Ultralytics Docs`
- `rg -n "yolox\.readthedocs\.io/en/latest/|YOLOX ReadTheDocs" docs/en/compare || true` returned no matches
- `curl -I -L --max-time 30 https://github.com/Megvii-BaseDetection/YOLOX/tree/main/docs` returned HTTP 200
- `git diff --check` passed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR standardizes and cleans up the model comparison docs by adding page titles, simplifying headings, and fixing outdated YOLOX documentation links across many comparison pages.

### 📊 Key Changes
- Added explicit `title` fields to the frontmatter of a large number of comparison pages for better page metadata and consistency 🏷️
- Simplified many top-level Markdown headings from long, editorial-style titles to short, uniform names like `Model A vs Model B` ✨
- Updated the comparison hub index title from a long descriptive heading to the cleaner `Model Comparisons` 📚
- Replaced outdated YOLOX ReadTheDocs links with the current GitHub docs path in multiple pages 🔗
- Applied these updates broadly across comparison docs covering DAMO-YOLO, EfficientDet, PP-YOLOE+, RTDETRv2, YOLO11, YOLO26, YOLOv5–YOLOv10, and YOLOX 🌍

### 🎯 Purpose & Impact
- Improves consistency across the docs site, making comparison pages easier to scan and navigate 👀
- Strengthens SEO and page rendering by ensuring each page has a clear, explicit title in frontmatter 🚀
- Makes page titles cleaner for readers, browser tabs, search results, and navigation menus 🧭
- Prevents broken or outdated external references by pointing YOLOX documentation links to an active source ✅
- Enhances overall docs polish without changing the technical substance of the comparison content 🛠️