### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         website: [www.ultralytics.com, docs.ultralytics.com, handbook.ultralytics.com]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install lychee
         run: |

--- a/.github/workflows/sitemaps.yml
+++ b/.github/workflows/sitemaps.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages # checkout gh-pages branch
           fetch-depth: 2 # fetch the current and previous commit

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: blob:none # full commit/tag history for describe/log, no historical site blobs (gh-pages history is ~2GB)


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates several GitHub Actions workflows in `ultralytics/docs` to use `actions/checkout@v7` instead of `@v6`, keeping the docs repository’s automation current.

### 📊 Key Changes
- Upgraded `actions/checkout` from `v6` to `v7` in four workflow files:
  - `.github/workflows/links.yml`
  - `.github/workflows/links_local.yml`
  - `.github/workflows/sitemaps.yml`
  - `.github/workflows/tag.yml`
- Applied the update across multiple automation tasks, including:
  - 🌐 link checking
  - 🧪 local link validation
  - 🗺️ sitemap generation
  - 🏷️ tagging-related workflows
- No workflow logic or behavior was otherwise changed; this is a version refresh only.

### 🎯 Purpose & Impact
- Improves ⚙️ maintenance by keeping GitHub Actions dependencies up to date.
- Helps support 🔒 security, compatibility, and reliability in CI/CD workflows.
- Reduces the chance of future issues caused by using older action versions.
- For users and contributors, the impact should be minimal and mostly behind the scenes ✅, but it helps keep docs automation stable and healthy.