### PR TITLE
Use quantize export arg in compare pages

### DIFF
--- a/docs/en/compare/pp-yoloe-vs-rtdetr.md
+++ b/docs/en/compare/pp-yoloe-vs-rtdetr.md
@@ -153,7 +153,7 @@ results = model_yolo("https://ultralytics.com/images/zidane.jpg")
 results[0].show()
 
 # Export for edge deployment in one line
-model_yolo.export(format="engine", half=True)
+model_yolo.export(format="engine", quantize=16)
 ```
 
 Lower memory requirements typical of Ultralytics YOLO models mean you can train faster and deploy on cheaper hardware compared to transformer-based counterparts. Furthermore, active development and world-class documentation ensure your production pipelines remain stable.

--- a/docs/en/compare/yolov10-vs-damo-yolo.md
+++ b/docs/en/compare/yolov10-vs-damo-yolo.md
@@ -58,7 +58,7 @@ results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 results = model("https://ultralytics.com/images/bus.jpg")
 
 # Export the model to TensorRT format
-model.export(format="engine", half=True)
+model.export(format="engine", quantize=16)
 ```
 
 ## Exploring DAMO-YOLO

--- a/docs/en/compare/yolov10-vs-efficientdet.md
+++ b/docs/en/compare/yolov10-vs-efficientdet.md
@@ -166,7 +166,7 @@ results = model("https://ultralytics.com/images/bus.jpg")
 results[0].show()
 
 # Export for rapid deployment
-model.export(format="engine", half=True)
+model.export(format="engine", quantize=16)
 ```
 
 ## Conclusion

--- a/docs/en/compare/yolov10-vs-pp-yoloe.md
+++ b/docs/en/compare/yolov10-vs-pp-yoloe.md
@@ -136,7 +136,7 @@ model = YOLO("yolo26n.pt")
 results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
 # Export to TensorRT for blazing fast deployment
-model.export(format="engine", half=True)
+model.export(format="engine", quantize=16)
 ```
 
 ## Real-World Applications

--- a/docs/en/compare/yolov8-vs-yolov9.md
+++ b/docs/en/compare/yolov8-vs-yolov9.md
@@ -108,7 +108,7 @@ model = YOLO("yolov8s.pt")
 results = model.train(data="custom_dataset.yaml", epochs=100, imgsz=640)
 
 # Export for edge deployment
-model.export(format="engine", half=True)  # TensorRT export
+model.export(format="engine", quantize=16)  # TensorRT export
 ```
 
 This single API dramatically reduces the time from prototype to production. Furthermore, YOLOv8 generally requires lower CUDA memory during training, allowing developers to use larger batch sizes on consumer-grade hardware.

--- a/docs/en/compare/yolov9-vs-yolov6.md
+++ b/docs/en/compare/yolov9-vs-yolov6.md
@@ -92,7 +92,7 @@ model = YOLO("yolov9c.pt")
 results = model.train(data="coco8.yaml", epochs=100, imgsz=640, device="0")
 
 # Export to ONNX or TensorRT seamlessly
-model.export(format="engine", half=True)
+model.export(format="engine", quantize=16)
 ```
 
 ### Unmatched Versatility Across Vision Tasks

--- a/docs/en/compare/yolox-vs-yolov10.md
+++ b/docs/en/compare/yolox-vs-yolov10.md
@@ -103,7 +103,7 @@ results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 predictions = model.predict("https://ultralytics.com/images/bus.jpg")
 
 # Export the model for edge deployment
-model.export(format="engine", half=True)
+model.export(format="engine", quantize=16)
 ```
 
 By leveraging built-in export routines, converting models to formats like [TensorRT](https://docs.ultralytics.com/integrations/tensorrt) or [ONNX](https://docs.ultralytics.com/integrations/onnx) requires just a single line of code, entirely bypassing complex compilation hurdles.

--- a/docs/en/compare/yolox-vs-yolov9.md
+++ b/docs/en/compare/yolox-vs-yolov9.md
@@ -107,7 +107,7 @@ model = YOLO("yolo26s.pt")
 results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
 # Easily export to optimized deployment formats
-model.export(format="engine", half=True)  # Exports to TensorRT
+model.export(format="engine", quantize=16)  # Exports to TensorRT
 ```
 
 Beyond detection, YOLO26 seamlessly supports a multitude of tasks within the exact same framework. Whether you need precise [Oriented Bounding Boxes (OBB)](https://docs.ultralytics.com/tasks/obb) for satellite imaging or fine-grained pixel masks for [medical imaging applications](https://docs.ultralytics.com/datasets/detect/brain-tumor), the workflow remains identical. For teams invested in previous generation workflows, [Ultralytics YOLO11](https://platform.ultralytics.com/ultralytics/yolo11) is also available and fully supported.


### PR DESCRIPTION
Updates the TensorRT export snippets on the model-comparison pages to use the new unified `quantize` export arg.

- `model.export(format="engine", half=True)` → `model.export(format="engine", quantize=16)` (FP16) across 8 compare pages.

The `quantize` arg comes from ultralytics/ultralytics#24918, which replaces the separate `half`/`int8` precision booleans with a single `quantize` value (`16` = FP16, `8` = INT8, `32` = FP32). This keeps the docs aligned with the new API. It should land after that PR ships the `quantize` arg.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates multiple model comparison docs to use the newer `quantize=16` TensorRT export syntax instead of `half=True`, keeping Ultralytics export examples consistent and up to date 🚀

### 📊 Key Changes
- Replaced `model.export(format="engine", half=True)` with `model.export(format="engine", quantize=16)` across several comparison pages.
- Updated TensorRT export examples in docs comparing:
  - PP-YOLOE vs RT-DETR
  - YOLOv10 vs DAMO-YOLO
  - YOLOv10 vs EfficientDet
  - YOLOv10 vs PP-YOLOE
  - YOLOv8 vs YOLOv9
  - YOLOv9 vs YOLOv6
  - YOLOX vs YOLOv10
  - YOLOX vs YOLOv9
- Kept the surrounding training, inference, and deployment examples unchanged, focusing only on export argument modernization 🛠️

### 🎯 Purpose & Impact
- Improves documentation accuracy by aligning examples with the current Ultralytics export API 📘
- Reduces confusion for users copying deployment commands from the docs, especially for TensorRT workflows ✅
- Helps maintain consistency across comparison articles, making the docs easier to trust and follow 🤝
- Supports smoother deployment onboarding for both new and experienced users targeting optimized edge or production inference ⚡