### PR TITLE
Tighten live-site spellcheck false positives

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -134,11 +134,11 @@ jobs:
           # 2-letter contributor initials (e.g. "BU" for Burhan-Q) that codespell
           # would otherwise flag as typos on every page.
           find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" \
-            -exec perl -0pi -e 's#<script\b[^>]*>.*?</script>##gis; s#<style\b[^>]*>.*?</style>##gis; s#<([a-z]+)\b[^>]*\bdata-slot="avatar-fallback"[^>]*>.*?</\1>##gis' {} +
+            -exec perl -0pi -e 's#<script\b[^>]*>.*?</script>##gis; s#<style\b[^>]*>.*?</style>##gis; s#<([a-z]+)\b[^>]*\bdata-slot="avatar-fallback"[^>]*>.*?</\1>##gis; s#[\x{2019}\x{2018}]#\x27#g' {} +
           CODESPELL_OUTPUT=$(find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" -print0 | xargs -0 codespell \
             --builtin clear,rare,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
-            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,nin,cancelled,MapPin,cann,CANN,Programme" \
+            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial" \
             --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/mkdocs_??.yml" \
             2>&1 || true)
 


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR improves the docs link-checking workflow by making spellcheck more reliable and reducing false positives from generated HTML content.

### 📊 Key Changes
- Added a preprocessing step in `.github/workflows/links.yml` to replace curly apostrophes with standard apostrophes before running `codespell`.
- Kept existing cleanup of embedded `<script>`, `<style>`, and avatar fallback HTML, while extending it to better normalize page text for spellchecking.
- Expanded the `codespell` ignore list with additional valid words and proper names, including `Vektor`, `MITRE`, and `Confidencial`.

### 🎯 Purpose & Impact
- ✅ Reduces unnecessary spellcheck failures caused by formatting differences in rendered HTML, especially smart quotes.
- 🔍 Helps CI focus on real spelling issues instead of flagging valid names or content-specific terms.
- 🚀 Makes documentation checks more stable and maintainable, which can speed up PR reviews and reduce noise for contributors.
- 🛠️ Improves the overall reliability of automated quality checks in the `ultralytics/docs` repository.