### PR TITLE
Ignore Hailo .alls extension in spellcheck

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -138,6 +138,7 @@ jobs:
           CODESPELL_OUTPUT=$(find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" -print0 | xargs -0 codespell \
             --builtin clear,rare,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
+            --ignore-regex '\.alls\b' \
             --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial" \
             --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/mkdocs_??.yml" \
             2>&1 || true)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fine-tunes the docs link/spell-check workflow by ignoring `.alls` matches in `codespell`, reducing false-positive spelling errors during CI.

### 📊 Key Changes
- Added `--ignore-regex '\.alls\b'` to the `codespell` command in `.github/workflows/links.yml`.
- This updates the GitHub Actions validation workflow used when checking generated HTML files.
- The change specifically tells spell-checking to skip text patterns matching `.alls`, which were likely being flagged incorrectly.

### 🎯 Purpose & Impact
- ✅ Reduces noisy CI failures caused by false-positive spell-check results.
- 🚀 Makes documentation checks more reliable, so contributors can focus on real issues instead of workflow quirks.
- 🧹 Helps streamline pull request reviews and docs maintenance in `ultralytics/docs`.
- 👩‍💻 Improves contributor experience by preventing unnecessary spell-check troubleshooting.