### PR TITLE
Ignore codespell false positive on "wasn't" contraction

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -139,7 +139,7 @@ jobs:
             --builtin clear,rare,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
             --ignore-regex '\.alls\b' \
-            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial" \
+            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial" \
             --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/mkdocs_??.yml" \
             2>&1 || true)
 


### PR DESCRIPTION
## Problem

The scheduled **Website links and spellcheck** workflow is failing on `www.ultralytics.com` with:

```
www.ultralytics.com/glossary/model-monitoring  wasn ==> wasn't, was
www.ultralytics.com/glossary/multimodal-rag    wasn ==> wasn't, was
```

This is a **false positive**. The source text is the correct contraction **"wasn't"** (verified in the CMS — `…data it wasn't trained on.`). The spellcheck step runs codespell over the *crawled rendered HTML*, where the apostrophe is the HTML entity `&#x27;` (`wasn&#x27;t`). codespell doesn't decode HTML entities, so it tokenizes `wasn` as a standalone word and matches its `wasn ==> wasn't, was` dictionary entry.

## Fix

Add `wasn't,wasn` to the codespell `--ignore-words-list`, mirroring the **existing `couldn't,couldn` entry** already in that list for the exact same entity-encoded-apostrophe case. No content change — the live text is already correct.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the docs repository’s link and spell-check workflow to ignore a few additional valid contractions, reducing false-positive spelling errors in CI.

### 📊 Key Changes
- Added `wasn't` and `wasn` to the `--ignore-words-list` in `.github/workflows/links.yml`.
- Kept the existing spell-check and link-check workflow intact, with only a small adjustment to the ignored words list.
- Improved handling of informal or contracted language that may appear in documentation content.

### 🎯 Purpose & Impact
- ✅ Reduces unnecessary CI warnings or failures caused by valid wording in docs.
- 🧹 Helps maintainers focus on real spelling and link issues instead of false alarms.
- 🚀 Makes the documentation workflow smoother and more reliable for contributors updating content.