### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/check_domains.yml
+++ b/.github/workflows/check_domains.yml
@@ -117,4 +117,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_WEBSITE }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S07ABRC4MLN> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@marketing-team` to cut company-wide notification noise.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the Slack alert message in the domain-check GitHub Actions workflow to make failure notifications shorter, clearer, and directed to a specific team group.

### 📊 Key Changes
- Replaced the Slack notification from a broad `<!channel>` alert to a targeted Slack user group mention: `<!subteam^S07ABRC4MLN>`.
- Simplified the failure message format in `.github/workflows/check_domains.yml`.
- Removed extra details from the alert, such as:
  - repository URL
  - workflow author
  - event name
- Kept the most important context in the message:
  - workflow name
  - repository name
  - direct link to the failed GitHub Actions run

### 🎯 Purpose & Impact
- 🎯 **Improves signal-to-noise ratio** by notifying the right team instead of alerting an entire channel.
- ⚡ **Makes failures easier to scan** with a shorter, cleaner Slack message.
- 🔗 **Speeds up response time** by keeping a direct link to the relevant workflow run.
- 🧹 **Reduces alert clutter** in Slack, which can help teams focus on actionable issues faster.