### PR TITLE
Compact Slack website QA alerts

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -159,7 +159,7 @@ jobs:
 
             # Prepare limited output for Slack (first 10 errors)
             SLACK_OUTPUT=$(echo "$MODIFIED_OUTPUT" | grep "==>" | head -10 | awk '{printf "%s\\n", $0}')
-            SLACK_HEADER="*${TOTAL_ERRORS} Spelling Errors*\\n\\n"
+            SLACK_HEADER="*${TOTAL_ERRORS} Spelling Errors*\\n"
             if [ "$TOTAL_ERRORS" -gt 10 ]; then
               SLACK_FOOTER="...$((TOTAL_ERRORS - 10)) more ➜ <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Action summary>"
             else
@@ -189,9 +189,7 @@ jobs:
             downloaded_files=$(find ${{ matrix.website }} -type f | wc -l)
             echo "Scanning $downloaded_files downloaded pages for broken links..."
 
-            # Create summary.txt with the total page count
-            echo "*Results for $downloaded_files pages*" > summary.txt
-            echo "" >> summary.txt
+            printf "Results for %s pages, " "$downloaded_files" > summary.txt
 
             rm -rf .lycheecache
             lychee \
@@ -221,7 +219,6 @@ jobs:
             ESCAPED_SUMMARY=$(grep -v "^\[TIMEOUT\]" summary.txt | \
               grep -v "^\[ERROR\]" | \
               grep -v "^Error:" | \
-              grep -v "Issues found in .* inputs" | \
               grep -F -v -f /tmp/skip_pages.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \
@@ -250,7 +247,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} GitHub Actions: Broken links found for *${{ matrix.website }}* ❌\n\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n\n${{ env.SUMMARY }}\n"
+            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ matrix.website }} broken links  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>\n${{ env.SUMMARY }}\n"
 
       - name: Notify Slack for spelling errors
         if: always() && steps.codespell.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
@@ -259,7 +256,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} GitHub Actions: Spelling errors found for *${{ matrix.website }}* 📝\n\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n\n${{ env.CODESPELL_ERRORS }}\n"
+            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} *${{ github.workflow }}* 📝 `${{ github.repository }}` ${{ matrix.website }} spelling errors  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>\n${{ env.CODESPELL_ERRORS }}\n"
 
       - name: Notify Slack for large images
         if: always() && steps.image_sizes.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
@@ -268,4 +265,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} GitHub Actions: Large images found for *${{ matrix.website }}* 📦\n\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n\n${{ env.IMAGE_RESULTS }}\n"
+            text: "${{ matrix.website == 'www.ultralytics.com' && '<!subteam^S07ABRC4MLN>' || '<!subteam^S082BPCRAJ3>' }} *${{ github.workflow }}* 📦 `${{ github.repository }}` ${{ matrix.website }} large images  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>\n${{ env.IMAGE_RESULTS }}\n"


### PR DESCRIPTION
## Summary
- compact scheduled website QA Slack headers into one line
- keep link, spelling, and image failure details directly under the header
- merge lychee page-count and issue-count boilerplate into one line

## Tests
- git diff --check -- .github/workflows/links.yml
- python3 YAML parse for .github/workflows/*.yml
- actionlint .github/workflows/links.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refines the docs link-check workflow to make Slack alerts and scan summaries cleaner, shorter, and easier to read 📬✨

### 📊 Key Changes
- Simplified the Slack header for spelling errors by removing extra blank lines, making notifications more compact 📝
- Changed broken-link scan output to start with a short inline summary like page count, instead of a multi-line header 📄
- Removed one filter that excluded the `Issues found in ... inputs` line, allowing more useful summary context to remain in the processed output 🔎
- Updated Slack notifications for broken links, spelling errors, and large images to use a more consistent format across all alert types 🎨
- Improved Slack messages by:
  - showing the workflow name
  - including the repository and website being checked
  - replacing raw URLs with a cleaner `Run` link
  - reducing extra metadata clutter such as separate action/author lines 🔗

### 🎯 Purpose & Impact
- Makes automated maintenance alerts easier for the team to scan quickly in Slack ⚡
- Improves consistency across different CI notifications, which helps reduce confusion when multiple checks fail at once ✅
- Preserves more relevant summary information from link-check results, potentially making debugging faster 🛠️
- Keeps the docs monitoring workflow more polished and actionable without changing the core validation behavior 📚