### PR TITLE
Trim broken link Slack summary

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -189,8 +189,6 @@ jobs:
             downloaded_files=$(find ${{ matrix.website }} -type f | wc -l)
             echo "Scanning $downloaded_files downloaded pages for broken links..."
 
-            printf "Results for %s pages, " "$downloaded_files" > summary.txt
-
             rm -rf .lycheecache
             lychee \
             --scheme 'https' \
@@ -206,7 +204,7 @@ jobs:
             --header "Accept-Language: *" \
             --header "Accept-Encoding: *" \
             --root-dir "$(pwd)/${{ matrix.website }}" \
-            './${{ matrix.website }}/**/*.html' | tee -a summary.txt
+            './${{ matrix.website }}/**/*.html' | tee summary.txt
 
             # Remove raw append; we'll print the cleaned version instead
             # cat summary.txt >> $GITHUB_STEP_SUMMARY   # CHANGED: removed
@@ -219,6 +217,7 @@ jobs:
             ESCAPED_SUMMARY=$(grep -v "^\[TIMEOUT\]" summary.txt | \
               grep -v "^\[ERROR\]" | \
               grep -v "^Error:" | \
+              grep -v -E "^Issues found in [0-9]+ inputs\. Find details below\.$" | \
               grep -F -v -f /tmp/skip_pages.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \


### PR DESCRIPTION
## Summary
- remove the prepended page-count sentence from broken-link Slack output
- filter lychee's issue-count preamble from the cleaned summary

## Tests
- git diff --check
- python3 YAML parse for .github/workflows/*.yml
- actionlint .github/workflows/links.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the docs broken-link checker workflow by producing cleaner, more focused GitHub Actions summaries 🧹🔗

### 📊 Key Changes
- Removed the custom “Results for X pages” prefix from `summary.txt` to avoid clutter in link-check output.
- Changed `lychee` output handling from appending to overwriting `summary.txt`, ensuring each run starts with fresh results.
- Added filtering to remove the generic `Issues found in X inputs. Find details below.` message from the cleaned summary.
- Keeps existing filtering for timeouts, errors, skipped pages, and noisy rejected-status-code text.

### 🎯 Purpose & Impact
- Makes broken-link reports easier to read in GitHub Actions ✅
- Reduces duplicate or low-value output so maintainers can focus on real link issues faster 🔍
- Improves CI report consistency and prevents stale or repeated summary content from previous steps 🛠️
- Helps maintain healthier Ultralytics documentation by making link-check failures clearer and quicker to triage 📚