### PR TITLE
Reduce broken-link false positives from bot-protected domains

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -3,6 +3,7 @@
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 401(Vimeo, 'unauthorized')
+#   - 402(Education Times, 'payment required' paywall)
 #   - 403(OpenVINO, 'forbidden')
 #   - 415(ClearML, 'unsupported media type')
 #   - 418(IEEE, "I'm a teapot" anti-bot challenge)
@@ -10,6 +11,8 @@
 #   - 500(Zenodo, 'cached')
 #   - 502(Zenodo, 'bad gateway')
 #   - 999(LinkedIn, 'unknown status code')
+# Also excludes domains whose bot protection rejects CI requests (HTTP/2 resets, connection refusals,
+# timeouts) even though the links load fine in a browser, e.g. mckinsey.com, adobe.com, gdpr.eu.
 
 name: Website links and spellcheck
 
@@ -194,9 +197,10 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,403,415,418,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,415,418,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|.*\.run\.app|.*\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -3,12 +3,15 @@
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 401(Vimeo, 'unauthorized')
+#   - 402(Education Times, 'payment required' paywall)
 #   - 403(OpenVINO, 'forbidden')
 #   - 415(ClearML, 'unsupported media type')
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
 #   - 502(Zenodo, 'bad gateway')
 #   - 999(LinkedIn, 'unknown status code')
+# Also excludes domains whose bot protection rejects CI requests (HTTP/2 resets, connection refusals,
+# timeouts) even though the links load fine in a browser, e.g. mckinsey.com, adobe.com, gdpr.eu.
 
 name: Check Broken Repo links
 
@@ -52,9 +55,9 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,403,415,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
@@ -75,9 +78,9 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,403,415,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
Daily `links.yml` runs keep flagging links that load fine in a browser. From the latest www.ultralytics.com run (63 affected pages), the failures fall into three buckets, none of them real broken links:

- **HTTP/2 protocol errors** — bot-protection CDNs (Akamai fronting mckinsey.com, st.com, adobe.com, dhl.com, etc.) reset HTTP/2 connections from non-browser TLS fingerprints. lychee has no HTTP/1.1 fallback option, so these can never verify from a CI runner.
- **Timeouts** — bot walls that stall datacenter IPs (gdpr.eu, mvtec.com, cv-foundation.org, ntrs.nasa.gov, …).
- **402 Payment Required** — educationtimes.com paywall. This was the only 4xx, so it alone failed the job and triggered the 3× 30-minute lychee retries (45-minute runs).

Changes, applied to both `links.yml` and `links_local.yml` to keep their configs in sync:

- Add `402` to `--accept`, same treatment as the existing 401/403 paywall/login codes.
- Merge the domain excludes into a single list and add the 27 bot-protected domains above. The `(www\.)?` prefix is generalized to `([a-zA-Z0-9-]+\.)*` so subdomains like `wiki.st.com` and `quickbooks.intuit.com` are covered.
- Add a `([:/?#]|$)` host boundary after the domain alternation so short entries can't suppress lookalike hosts (`st.com` no longer matches `st.com.au`; previously `tesla.com` matched `tesla.communications.net`-style hosts).
- Split the non-domain infra patterns (`.run.app`, `.cloudfunctions.net`, the `0.0.0.0:5543` predict endpoint) into their own exclude in `links.yml`.

Validated: YAML parses, and the final regexes were tested against all 30 flagged URLs from the failing run (all excluded) plus lookalike hosts (`st.com.au`, `best.com`, `nasa.gov`, `cs.uchicago.edu`, `intuition.com` — all still checked). With these changes that run would have passed clean on the first attempt.

Trade-off: genuinely dead pages on the excluded domains won't be caught, same as the existing linkedin/twitter/fda.gov exclusions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves documentation link-checking reliability by reducing false positives from paywalled or bot-protected websites 🔗✅

### 📊 Key Changes
- Added HTTP `402 Payment Required` to accepted link-check statuses for paywalled sites like Education Times 💳
- Expanded excluded domains in link-check workflows to include sites that block or fail CI bot requests despite working in browsers 🤖🚧
- Updated both hosted and local link-check workflows: `.github/workflows/links.yml` and `.github/workflows/links_local.yml` 🛠️
- Improved regex handling to support subdomains more broadly and separate certain platform URL exclusions like `.run.app` and `.cloudfunctions.net` 🔍
- Added comments explaining why specific status codes and domains are ignored for better workflow maintainability 📝

### 🎯 Purpose & Impact
- Reduces noisy CI failures caused by external websites with paywalls, anti-bot protections, timeouts, or connection resets 🚦
- Helps maintainers focus on real broken links instead of known third-party access issues 🎯
- Makes documentation checks more stable and predictable for contributors and reviewers ✅
- Improves long-term maintainability by documenting the rationale behind link-check exceptions 📚