### PR TITLE
Strip singular lychee summary preamble

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -221,7 +221,7 @@ jobs:
             ESCAPED_SUMMARY=$(grep -v "^\[TIMEOUT\]" summary.txt | \
               grep -v "^\[ERROR\]" | \
               grep -v "^Error:" | \
-              grep -v -E "^Issues found in [0-9]+ inputs\. Find details below\.$" | \
+              grep -v -E "^Issues found in [0-9]+ inputs?\. Find details below\.$" | \
               grep -F -v -f /tmp/skip_pages.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \


### PR DESCRIPTION
## Summary
- strip both singular and plural lychee preamble lines from the broken-link summary
- keep the existing Slack and Actions summary cleanup path unchanged otherwise

## Validation
- rg --hidden --glob "!.git" "Issues found in|Find details below|summary\.txt|ESCAPED_SUMMARY|Notify Slack for broken links|SLACK_MESSAGE|lychee"
- git diff --check
- python3 YAML parse for links.yml and links_local.yml
- actionlint .github/workflows/links.yml .github/workflows/links_local.yml
- regex smoke test for singular and plural lychee preambles

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the docs link-checking workflow by making its summary filtering more robust for both singular and plural issue messages 🔗✅

### 📊 Key Changes
- Updated the GitHub Actions link-check filter in `.github/workflows/links.yml`.
- Adjusted the regex to match both:
  - `Issues found in 1 input. Find details below.`
  - `Issues found in 2 inputs. Find details below.`
- This is a small CI workflow refinement with no documentation content changes.

### 🎯 Purpose & Impact
- Prevents noisy or unnecessary link-check summary lines from appearing in workflow output 🧹
- Makes CI logs cleaner and easier to review for maintainers 👀
- Reduces confusion when link checks report issues from only one input versus multiple inputs ⚙️