### PR TITLE
Add 'bale' to codespell ignore words

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -142,7 +142,7 @@ jobs:
             --builtin clear,rare,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
             --ignore-regex '\.alls\b' \
-            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial" \
+            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial,bale" \
             --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/mkdocs_??.yml" \
             2>&1 || true)
 


### PR DESCRIPTION
## Summary

Adds `bale` to the codespell `--ignore-words-list` in the website spellcheck (`links.yml`).

The daily www.ultralytics.com spellcheck flags `bale ==> able, bail` on the Glacier Robotics customer story, but the word is correct recycling terminology there ("a bale of aluminium contaminated with the wrong materials loses value").

The other flagged errors on that page (`aluminium ==> aluminum`) were real and have been fixed directly in the CMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the docs link/spellcheck workflow to recognize “bale” as an allowed word, reducing false-positive spelling alerts ✅

### 📊 Key Changes
- Added `bale` to the `--ignore-words-list` in `.github/workflows/links.yml` 📝
- Keeps the existing link and documentation validation workflow unchanged aside from this spelling exception 🔍

### 🎯 Purpose & Impact
- Prevents CI checks from incorrectly flagging “bale” as a typo 🚦
- Helps maintain smoother documentation validation with fewer unnecessary warnings ⚙️
- Improves contributor experience by reducing noise in automated checks 🙌