### PR TITLE
Exclude bot-protected publication links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,7 +6,6 @@
 #   - 402(Education Times, 'payment required' paywall)
 #   - 403(OpenVINO, 'forbidden')
 #   - 415(ClearML, 'unsupported media type')
-#   - 418(IEEE, "I'm a teapot" anti-bot challenge)
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
 #   - 502(Zenodo, 'bad gateway')
@@ -43,7 +42,8 @@ jobs:
     strategy:
       fail-fast: false # This ensures that if one job fails, the others will still run
       matrix:
-        website: [www.ultralytics.com, docs.ultralytics.com, handbook.ultralytics.com]
+        website:
+          [www.ultralytics.com, docs.ultralytics.com, handbook.ultralytics.com]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -197,9 +197,9 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,402,403,415,418,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -57,7 +57,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
@@ -80,7 +80,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
## Summary

- exclude IEEE Xplore and ScienceDirect from live link checks because both reject automated CI requests
- keep the shared bot-protected-domain regex synchronized across scheduled and local link workflows
- remove the obsolete IEEE HTTP 418 exception

## Validation

- `uv run python` YAML parsing and exclusion-regex assertions
- `npx prettier --check .github/workflows/links.yml .github/workflows/links_local.yml`
- `git diff --check`

Fixes the false positives in https://github.com/ultralytics/docs/actions/runs/29234228694

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves documentation link-checking workflows by updating excluded domains and removing an outdated HTTP status exception. 🔗

### 📊 Key Changes
- Removed the obsolete HTTP 418 exception from the main link checker.
- Added `ieeexplore.ieee.org` and `sciencedirect.com` to excluded domains in both link-checking workflows.
- Reformatted the website matrix for improved YAML readability.
- Kept exclusions synchronized across hosted and local link-checking workflows.

### 🎯 Purpose & Impact
- Prevents known anti-bot and access restrictions from causing false link-check failures. ✅
- Makes automated checks more reliable for academic and research links.
- Ensures consistent behavior between CI-based and local documentation link validation.
- Reduces unnecessary maintenance caused by outdated status-code handling.