### PR TITLE
Exclude bot-protected IEEE links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -202,7 +202,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -57,7 +57,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
@@ -80,7 +80,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieeexplore\.ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(/\$|%7B|api\.indexnow\.org)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
## Summary

Replace the narrow ieeexplore.ieee.org exclusion with ieee.org so the existing bot-protection rule also covers the root IEEE site, which returns HTTP 418 to the scheduled checker while loading normally for users. Keep the shared exclusion identical in links.yml and both links_local.yml jobs.

## Validation

- actionlint .github/workflows/links.yml .github/workflows/links_local.yml
- parsed both workflows with Ruby YAML
- verified the regex matches www.ieee.org and ieeexplore.ieee.org but not notieee.org
- git diff --check

Deleted: the redundant subdomain-only ieeexplore.ieee.org exclusion; the parent IEEE domain now owns both cases.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated documentation link-checking workflows to cover all `ieee.org` subdomains more reliably. 🔗

### 📊 Key Changes
- Replaced the narrower `ieeexplore.ieee.org` exclusion with the broader `ieee.org` domain exclusion.
- Applied the update consistently to both standard and local link-checking workflows.
- Preserved the existing exclusions and link validation settings.

### 🎯 Purpose & Impact
- Prevents link-checking jobs from flagging inaccessible or restricted IEEE links as failures. ✅
- Improves CI reliability for documentation containing links to IEEE publications and resources.
- Reduces false-positive link errors without affecting validation for other domains.