### PR TITLE
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Notify Slack for broken links
         if: always() && steps.lychee.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -257,7 +257,7 @@ jobs:
 
       - name: Notify Slack for spelling errors
         if: always() && steps.codespell.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Notify Slack for large images
         if: always() && steps.image_sizes.outcome == 'failure' && github.event_name == 'schedule' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ matrix.website == 'www.ultralytics.com' && secrets.SLACK_WEBHOOK_URL_WEBSITE || secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔔 Updates Slack notifications in the documentation CI workflow to Slack GitHub Action v4.0.0.

### 📊 Key Changes

- Upgraded the Slack GitHub Action from `v3.0.5` to `v4.0.0`.
- Applied the update to notifications for:
  - Broken links 🔗
  - Spelling errors ✍️
  - Oversized images 🖼️
- Preserved the existing webhook configuration and notification conditions.

### 🎯 Purpose & Impact

- ✅ Keeps CI notifications aligned with the latest supported Slack action version.
- 📣 Maintains automated Slack alerts when scheduled documentation checks fail.
- 🛠️ May provide improved compatibility, security, and reliability through the newer action release.
- 👥 No direct impact on documentation users, but contributors and maintainers benefit from more up-to-date CI tooling.