### PR TITLE
Improve broken link Slack summaries

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -213,32 +213,44 @@ jobs:
             --root-dir "$(pwd)/${{ matrix.website }}" \
             './${{ matrix.website }}/**/*.html' | tee summary.txt
 
-            # Remove raw append; we'll print the cleaned version instead
-            # cat summary.txt >> $GITHUB_STEP_SUMMARY   # CHANGED: removed
-
             # Two-pass approach to remove timeout and network error entries
             # First pass: identify pages followed by TIMEOUT or network error entries
             grep -B1 -E "^\[TIMEOUT\]|^\[ERROR\]|^Error:" summary.txt | grep "\.html\]:$" > /tmp/skip_pages.txt 2>/dev/null || true
 
             # Second pass: remove TIMEOUT/Error lines, their pages, and squeeze blank lines
-            ESCAPED_SUMMARY=$(grep -v "^\[TIMEOUT\]" summary.txt | \
+            grep -v "^\[TIMEOUT\]" summary.txt | \
               grep -v "^\[ERROR\]" | \
               grep -v "^Error:" | \
               grep -v -E "^Issues found in [0-9]+ inputs?\. Find details below\.$" | \
               grep -F -v -f /tmp/skip_pages.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \
-              sed 's/\[//g; s/\]//g; s/\.html//g; s/"/\\"/g' | \
-              awk '{printf "%s\\n", $0}')
+              sed 's/\[//g; s/\]//g; s/\.html//g; s/"/\\"/g' > /tmp/cleaned_summary.txt
 
-            # Show the same cleaned output in the Actions summary (matches Slack)
-            printf "%b" "$ESCAPED_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+            # Keep the full output in Actions
+            cat /tmp/cleaned_summary.txt >> "$GITHUB_STEP_SUMMARY"
+
+            # Prepare limited output for Slack (first 10 errors)
+            TOTAL_ERRORS=$(grep -cE '^[0-9]{3} https?://' /tmp/cleaned_summary.txt || true)
+            MODIFIED_OUTPUT=$(awk '
+              /:$/ { page = $0; sub(/:$/, "", page); next }
+              /^[0-9][0-9][0-9] https?:\/\// { print page "  " $0 }
+            ' /tmp/cleaned_summary.txt | perl -pe '
+              s{(https?://\S+)}{"<$1|" . (length($1) > 80 ? substr($1, 0, 77) . "..." : $1) . ">"}ge
+            ')
+            SLACK_OUTPUT=$(echo "$MODIFIED_OUTPUT" | head -10 | awk '{printf "%s\\n", $0}')
+            SLACK_HEADER="*${TOTAL_ERRORS} Broken Links*\\n"
+            if [ "$TOTAL_ERRORS" -gt 10 ]; then
+              SLACK_FOOTER="...$((TOTAL_ERRORS - 10)) more ➜ <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Action summary>"
+            else
+              SLACK_FOOTER=""
+            fi
 
             # Cleanup
-            rm -f /tmp/skip_pages.txt
+            rm -f /tmp/cleaned_summary.txt /tmp/skip_pages.txt
 
             echo "SUMMARY<<EOF" >> $GITHUB_ENV
-            echo "$ESCAPED_SUMMARY" >> $GITHUB_ENV
+            echo "${SLACK_HEADER}${SLACK_OUTPUT}${SLACK_FOOTER}" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
 
             # Raise error only if 4xx errors remain (not network errors, timeouts, or server errors)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -230,7 +230,7 @@ jobs:
             ' summary.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \
-              sed 's/\[//g; s/\]//g; s/\.html:$/:/; s/"/\\"/g' > /tmp/cleaned_summary.txt
+              sed -E 's/^\[([^]]*)\.html\]:$/\1:/; s/^\[([0-9]{3})\] /\1 /; s/"/\\"/g' > /tmp/cleaned_summary.txt
 
             # Keep the full output in Actions
             cat /tmp/cleaned_summary.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -230,7 +230,7 @@ jobs:
             ' summary.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \
-              sed 's/\[//g; s/\]//g; s/\.html//g; s/"/\\"/g' > /tmp/cleaned_summary.txt
+              sed 's/\[//g; s/\]//g; s/\.html:$/:/; s/"/\\"/g' > /tmp/cleaned_summary.txt
 
             # Keep the full output in Actions
             cat /tmp/cleaned_summary.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -213,16 +213,21 @@ jobs:
             --root-dir "$(pwd)/${{ matrix.website }}" \
             './${{ matrix.website }}/**/*.html' | tee summary.txt
 
-            # Two-pass approach to remove timeout and network error entries
-            # First pass: identify pages followed by TIMEOUT or network error entries
-            grep -B1 -E "^\[TIMEOUT\]|^\[ERROR\]|^Error:" summary.txt | grep "\.html\]:$" > /tmp/skip_pages.txt 2>/dev/null || true
-
-            # Second pass: remove TIMEOUT/Error lines, their pages, and squeeze blank lines
-            grep -v "^\[TIMEOUT\]" summary.txt | \
-              grep -v "^\[ERROR\]" | \
-              grep -v "^Error:" | \
-              grep -v -E "^Issues found in [0-9]+ inputs?\. Find details below\.$" | \
-              grep -F -v -f /tmp/skip_pages.txt | tr -d '\r' | \
+            # Keep numeric errors with their page while removing timeout and network errors
+            awk '
+              function flush() {
+                if (errors) {
+                  print page
+                  printf "%s", errors
+                  print ""
+                }
+                errors = ""
+              }
+              /^\[.*\.html\]:$/ { flush(); page = $0; next }
+              /^\[[0-9][0-9][0-9]\] https?:\/\// { errors = errors $0 ORS; next }
+              / Total \(in / { flush(); print }
+              END { flush() }
+            ' summary.txt | tr -d '\r' | \
               sed -E 's/[[:space:]]*\|[[:space:]]*Rejected status code[^:]*:[[:space:]]*/ | /g' | \
               cat -s | \
               sed 's/\[//g; s/\]//g; s/\.html//g; s/"/\\"/g' > /tmp/cleaned_summary.txt
@@ -232,13 +237,12 @@ jobs:
 
             # Prepare limited output for Slack (first 10 errors)
             TOTAL_ERRORS=$(grep -cE '^[0-9]{3} https?://' /tmp/cleaned_summary.txt || true)
-            MODIFIED_OUTPUT=$(awk '
+            SLACK_OUTPUT=$(awk '
               /:$/ { page = $0; sub(/:$/, "", page); next }
-              /^[0-9][0-9][0-9] https?:\/\// { print page "  " $0 }
+              /^[0-9][0-9][0-9] https?:\/\// && shown++ < 10 { print page "  " $0 }
             ' /tmp/cleaned_summary.txt | perl -pe '
               s{(https?://\S+)}{"<$1|" . (length($1) > 80 ? substr($1, 0, 77) . "..." : $1) . ">"}ge
-            ')
-            SLACK_OUTPUT=$(echo "$MODIFIED_OUTPUT" | head -10 | awk '{printf "%s\\n", $0}')
+            ' | awk '{printf "%s\\n", $0}')
             SLACK_HEADER="*${TOTAL_ERRORS} Broken Links*\\n"
             if [ "$TOTAL_ERRORS" -gt 10 ]; then
               SLACK_FOOTER="...$((TOTAL_ERRORS - 10)) more ➜ <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Action summary>"
@@ -247,7 +251,7 @@ jobs:
             fi
 
             # Cleanup
-            rm -f /tmp/cleaned_summary.txt /tmp/skip_pages.txt
+            rm -f /tmp/cleaned_summary.txt
 
             echo "SUMMARY<<EOF" >> $GITHUB_ENV
             echo "${SLACK_HEADER}${SLACK_OUTPUT}${SLACK_FOOTER}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- format broken-link alerts like spelling alerts with one compact line per error
- show only the first 10 errors and link to the full Actions summary
- truncate long URL labels while preserving their full clickable destinations

## Validation

- `npx prettier --check .github/workflows/links.yml`
- `actionlint .github/workflows/links.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves broken-link reporting by preserving useful error details in GitHub Actions while sending a concise, limited summary to Slack. 🔗

### 📊 Key Changes
- Replaced the previous multi-step `grep` filtering with an `awk`-based parser.
- Preserves numeric HTTP errors and associates them with the affected HTML page.
- Removes timeout and network-error noise from the main report.
- Keeps the complete cleaned report in the GitHub Actions summary.
- Limits Slack notifications to the first 10 broken links.
- Adds a count of total broken links and links to the full Actions summary when more errors exist.
- Improves URL formatting in Slack with shortened clickable links.
- Continues failing the workflow only for remaining 4xx errors.

### 🎯 Purpose & Impact
- Makes link-checking results more accurate and easier to understand. ✅
- Gives developers full diagnostic details in GitHub Actions without overwhelming Slack.
- Reduces notification noise while preserving access to complete results.
- Helps distinguish actionable broken links from transient network failures and timeouts.