### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install lychee and dependencies
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
## Summary

- replace both Astral uv setup steps with the shared retried owner
- preserve the existing link-check and release workflows

Reused: `ultralytics/actions/setup-uv@main` is the single latest-uv installer owner.

Deleted: two direct `astral-sh/setup-uv` dependencies.

## Validation

- zero `uses: astral-sh/setup-uv` occurrences
- `actionlint` on both changed workflows
- `git diff --check`
- shared owner passed Windows, Ubuntu, and macOS CI in ultralytics/actions#819

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updated documentation workflows to use Ultralytics’ shared `setup-uv` GitHub Action.

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in:
  - The link-checking workflow.
  - The tag-management workflow.
- Kept the existing Python setup and dependency installation steps unchanged.

### 🎯 Purpose & Impact

- ✅ Centralizes `uv` setup through Ultralytics’ shared Actions repository.
- 🔄 Makes workflow maintenance and future updates easier across projects.
- 🚀 Ensures link checks and tag automation use a consistent internal setup.
- ⚠️ Because the action tracks `@main`, workflow behavior may change when the shared action is updated.