### PR TITLE
Remove codespell `rare` dictionary from website spellcheck

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -142,7 +142,7 @@ jobs:
           find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" \
             -exec perl -0pi -e 's#<script\b[^>]*>.*?</script>##gis; s#<style\b[^>]*>.*?</style>##gis; s#<([a-z]+)\b[^>]*\bdata-slot="avatar-fallback"[^>]*>.*?</\1>##gis; s#[\x{2019}\x{2018}]#\x27#g' {} +
           CODESPELL_OUTPUT=$(find "$SPELLCHECK_ROOT/${{ matrix.website }}" -type f -name "*.html" -print0 | xargs -0 codespell \
-            --builtin clear,rare,informal,en-GB_to_en-US \
+            --builtin clear,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
             --ignore-regex '\.alls\b' \
             --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial,bale" \


### PR DESCRIPTION
## Summary

The daily `Website links and spellcheck` workflow reports valid LVIS class names as spelling errors:

- `manger` → `manager`
- `trough` → `through`

Both are valid nouns in the LVIS class label `manger/trough` (an animal-feeding container) and should not be "corrected".

## Root cause

The `Check spelling` step in `.github/workflows/links.yml` runs codespell with `--builtin clear,rare,informal,en-GB_to_en-US`. Codespell's `rare` dictionary explicitly maps both words as likely typos:

```
dictionary_rare.txt :: manger->manager
dictionary_rare.txt :: trough->through
```

Verified these two entries exist **only** in `dictionary_rare.txt`, not in `clear`, `informal`, or `en-GB_to_en-US`, so removing `rare` fixes them at the source with no reappearance from another dictionary.

## Change

```diff
-            --builtin clear,rare,informal,en-GB_to_en-US \
+            --builtin clear,informal,en-GB_to_en-US \
```

This fixes the source rather than adding individual `--ignore-words-list` exceptions, keeping the high-confidence `clear`, `informal`, and `en-GB_to_en-US` checks that are appropriate for a Slack-paging daily check.

## Trade-off

Dropping `rare` also drops its coverage of other genuine-but-uncommon typos. That is the deliberate trade: `rare` is opt-in precisely because it assumes uncommon-but-valid words are probably typos — the wrong premise for scanning a real technical website full of model names, dataset labels, and ML jargon. For a daily check that pages a human via Slack, noise reduction is the right call.

## Notes

- `.github/workflows/links.yml` line 145 is the only `rare` usage in this repo. The `format.yml` spellcheck delegates to Ultralytics Actions (`spelling: true`); the same fix there is tracked in ultralytics/actions#823.

Closes #340

Ref: Slack thread https://ultralytics-work.slack.com/archives/C01EDRWJ95W/p1784360628239059

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes the Codespell `rare` dictionary from the website spellcheck workflow. 🔤

### 📊 Key Changes
- Updates `.github/workflows/links.yml` to stop using the `rare` Codespell dictionary.
- Retains the `clear`, `informal`, and `en-GB_to_en-US` dictionaries and existing ignore rules.

### 🎯 Purpose & Impact
- Reduces false-positive spelling warnings caused by uncommon or domain-specific words.
- Makes website spellcheck results more focused and maintainable without changing documentation content. ✅