### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,7 +62,7 @@ jobs:
           git push origin "${{ github.event.inputs.tag_name }}"
 
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated GitHub Actions workflows to use the latest `actions/setup-python` version. ⚙️

### 📊 Key Changes

- Upgraded `actions/setup-python` from `v6` to `v7` in:
  - The link-checking workflow.
  - The tag-release workflow.
- No changes were made to documentation content or workflow behavior.

### 🎯 Purpose & Impact

- Keeps CI workflows aligned with the latest supported GitHub Action version. ✅
- May provide improved compatibility, maintenance, and security for Python environment setup.
- Link validation and tag-based release processes should continue working as before. 🚀