### PR TITLE
Ignore HSI in website spellcheck

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -145,7 +145,7 @@ jobs:
             --builtin clear,informal,en-GB_to_en-US \
             --uri-ignore-words-list "*" \
             --ignore-regex '\.alls\b' \
-            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial,bale" \
+            --ignore-words-list "Ain't,grey,writeable,MENAT,Hart,wither,Bund,DED,AKS,VAs,RepResNet,iDenfy,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,tread,braket,corse,SoM,couldn't,couldn,wasn't,wasn,nin,cancelled,MapPin,cann,CANN,Vektor,MITRE,Confidencial,bale,HSI" \
             --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/mkdocs_??.yml" \
             2>&1 || true)
 


### PR DESCRIPTION
Requested by glenn.jocher@ultralytics.com (job `7c02d8246713`).

Deleted: nothing — the task is a one-token addition to codespell's existing `--ignore-words-list`; no deletion or replacement was possible since a needed exclusion word did not previously exist, and the change reuses the sole existing exclusion owner.

```
.github/workflows/links.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added `HSI` to the documentation link-check workflow’s accepted word list to prevent false spelling warnings. ✅

### 📊 Key Changes
- Updated `.github/workflows/links.yml`.
- Added `HSI` to the `--ignore-words-list` configuration for automated checks.

### 🎯 Purpose & Impact
- Prevents the link-validation workflow from flagging the valid technical acronym `HSI`.
- Keeps documentation CI checks focused on genuine spelling or link issues.
- Has no direct impact on users or runtime behavior.