### PR TITLE
Exclude flaky Gitee URL from link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -204,6 +204,7 @@ jobs:
             --exclude-all-private \
             --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
+            --exclude '^https://gitee\.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench/?$' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \


### PR DESCRIPTION
### What changed
Both repos' link checks now exclude only the exact Gitee ais_bench URL via an anchored `--exclude` regex on all three lychee commands; 405 from any other URL still fails since 405 stays out of `--accept`. Unverified: no live lychee/CI run was executed (sandbox has no network), only local regex-behavior validation.

### Why
Update the existing Lychee link-check workflows to exclude only `https://gitee.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench`, which intermittently returns HTTP 405 to GitHub-hosted runners despite being reachable. In `ultralytics/docs`, the owner is `.github/workflows/links.yml`, specifically the existing `lychee` command in the `Check broken links` step. In `ultralytics/ultralytics`, the owner is `.github/workflows/links.yml`, specifically both existing `lychee` commands in the scheduled/manual link-check steps. Preserve the existing retry behavior, accepted status codes, headers, and all other exclusions. Acceptance boundary: this exact Gitee URL is ignored by both repositories' link checks, while HTTP 405 responses from any other URL continue to be reported as failures.

Requested by murat@ultralytics.com (job `de69eb2b41d7`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Excludes a known problematic Gitee URL from automated documentation link checks. 🔗

### 📊 Key Changes
- Added a targeted exclusion for the `ais-bench_workload` URL on Gitee in the links-checking GitHub Actions workflow.
- Keeps the existing link validation process unchanged for all other documentation links.

### 🎯 Purpose & Impact
- Prevents recurring false positives or unreliable checks caused by the excluded Gitee page. ✅
- Helps documentation CI complete more reliably without masking unrelated broken links.
- No direct user-facing documentation or API changes.