### PR TITLE
Exclude gitee.com from website link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -202,7 +202,7 @@ jobs:
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com|gitee\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
Fixes the `Website links and spellcheck` failure on docs.ultralytics.com:

```
docs.ultralytics.com/integrations/ascend:
405 https://gitee.com/ascend/tools/tree/master/ais-bench_workload/tool/ais_bench (at 193:188) | 405 Method Not Allowed
```

The URL returns 200 in a browser — gitee.com's bot protection rejects CI requests, which is exactly what this exclusion list covers. Companion PR keeping the source-side check green: ultralytics/ultralytics#25449.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated link-checking automation to exclude `gitee.com` URLs from validation.

### 📊 Key Changes
- Added `gitee.com` to the external-domain exclusion list in `.github/workflows/links.yml`.
- The link checker will now skip all matching Gitee URLs, including subdomains and URLs with paths or query parameters.

### 🎯 Purpose & Impact
- Prevents expected external Gitee links from causing automated documentation checks to fail. ✅
- Makes link validation more reliable by excluding a domain that may be inaccessible or difficult to verify automatically.
- No changes to documentation content or user-facing functionality.