### PR TITLE
Bump actions/stale from v10 to v11 in /.github/workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Bump actions/stale from v10 to v11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the stale issue management workflow to use the latest `actions/stale` release. 🔄

### 📊 Key Changes

- Upgraded GitHub Actions Stale from `actions/stale@v10` to `actions/stale@v11`.
- No changes were made to the workflow configuration or stale issue behavior.

### 🎯 Purpose & Impact

- Keeps the repository’s automation aligned with the latest supported action version. ✅
- May provide maintenance updates, fixes, and security improvements from `actions/stale@v11`.
- Existing stale issue and pull request management should continue working as before.