### PR TITLE
Exclude chemistryworld.com from website link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,7 +5,6 @@
 #   - 401(Vimeo, 'unauthorized')
 #   - 402(Education Times, 'payment required' paywall)
 #   - 403(OpenVINO, 'forbidden')
-#   - 405(Chemistry World, 'method not allowed')
 #   - 415(ClearML, 'unsupported media type')
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
@@ -201,9 +200,9 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,402,403,405,415,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
             --exclude-all-private \
-            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com|gitee\.com)([:/?#]|$)' \
+            --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com|gitee\.com|chemistryworld\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,6 +5,7 @@
 #   - 401(Vimeo, 'unauthorized')
 #   - 402(Education Times, 'payment required' paywall)
 #   - 403(OpenVINO, 'forbidden')
+#   - 405(Chemistry World, 'method not allowed')
 #   - 415(ClearML, 'unsupported media type')
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
@@ -200,7 +201,7 @@ jobs:
             --scheme 'https' \
             --timeout 60 \
             --insecure \
-            --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
+            --accept 100..=103,200..=299,302,401,402,403,405,415,429,500..=599,999 \
             --exclude-all-private \
             --exclude 'https?://([a-zA-Z0-9-]+\.)*(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|tiktok\.com|fonts\.gstatic\.com|fonts\.googleapis\.com|url\.com|tesla\.com|wellfound\.com|fda\.gov|ieee\.org|sciencedirect\.com|mckinsey\.com|st\.com|adobe\.com|dhl\.com|avangrid\.com|bhp\.com|businesswire\.com|bmw\.in|intuit\.com|epo\.org|orangepi\.org|gdpr\.eu|mvtec\.com|cv-foundation\.org|ntrs\.nasa\.gov|elib\.dlr\.de|burrsettles\.com|biomecardio\.com|glaze\.cs\.uchicago\.edu|miquido\.com|forensicexpertinvestigation\.com|newspace\.co\.in|agriplanting\.com|revistafuera\.com|ravindersingal\.com|qsdca\.com\.au|videologicanalytics\.com|gitee\.com)([:/?#]|$)' \
             --exclude '(\.run\.app|\.cloudfunctions\.net|0\.0\.0\.0:5543/predict/from_files)' \


### PR DESCRIPTION
## Problem

The daily [Website links and spellcheck](https://github.com/ultralytics/docs/actions/runs/31246007926) run failed on `www.ultralytics.com` across the initial attempt and all 3 retries:

```
[www.ultralytics.com/blog/agentic-ai-and-computer-vision-the-future-of-automation.html]:
[405] https://www.chemistryworld.com/news/computer-vision-accelerates-self-driving-reaction-workups-from-being-automated-to-autonomous/4018706.article (at 40:46) | Rejected status code: 405 Method Not Allowed
```

That link is not broken. It returns `200` from a normal client on both `HEAD` and `GET`; the `405` is a WAF response to GitHub runner IPs — the same bot-protection pattern the workflow header already documents.

The other 11 URLs the run reported were `[TIMEOUT]`/`[ERROR]`, which the gate does not fail on. Each was checked anyway and **every one returns `200`**: `gdpr-info.eu`, `hls.gsfc.nasa.gov`, `appliedsciences.nasa.gov`, `csitcp.com`, `ewastemonitor.info`, `betabionics.com`, `cemesa.org`, `biometricupdate.com`, `nexusintegra.io`, `aetic.theiaer.org`, `yearlymagazine.com`. So there is nothing to replace or remove in the published content — this is purely a checker false positive.

## Fix

Add `chemistryworld.com` to the bot-protected domain exclusion list in `links.yml`, matching the `gitee.com` precedent from #347.

Scoped to `links.yml` only: the URL appears on www.ultralytics.com, not in this repo, so `links_local.yml` is unchanged — same scoping as #347.

## Validation

Ran lychee 0.24.2 with the exact `--exclude` regex from the updated file, against the failing URL plus a control and a lookalike domain:

```
[ERROR] https://www.chemistryworldx.com/y | Connection failed
🔍 3 Total  🔗 3 Unique  ✅ 1 OK  🚫 1 Error  👻 1 Excluded
```

- the failing Chemistry World URL → **Excluded**
- `https://www.rust-lang.org/` control → still checked, **OK**
- `chemistryworldx.com` lookalike → still checked, **not** shielded by the new pattern

So the exclusion matches the intended domain and nothing wider. YAML parse verified.

## Review note

The first commit accepted `405` globally via `--accept`. Per review that was too broad — lychee's `--accept` is a global list, so it would have masked method-restricted URLs across all four sites. Reverted in favour of the targeted domain exclusion; the net diff against `main` is one line.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the documentation link checker to exclude `chemistryworld.com` URLs from automated validation. 🔗

### 📊 Key Changes

- Added `chemistryworld.com` to the link-checking workflow’s excluded domain list.
- No documentation content or application code was modified.

### 🎯 Purpose & Impact

- Prevents unreliable or inaccessible external Chemistry World links from causing link-check workflow failures. ✅
- Improves CI stability while preserving automated checks for other documentation links.
- Users will see no direct documentation changes, but maintainers should experience fewer false-positive link errors.