### PR TITLE
Fix Docs validation instructions

### DIFF
--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -41,7 +41,7 @@ jobs:
           curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
             sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
-      - name: Test Markdown and HTML links with retry
+      - name: Test Markdown links with retry
         uses: ultralytics/actions/retry@main
         with:
           timeout_minutes: 60
@@ -60,10 +60,9 @@ jobs:
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
-            './**/*.md' \
-            './**/*.html'
+            './**/*.md'
 
-      - name: Test Website, Markdown, HTML, YAML, Python and Notebook links with retry
+      - name: Test Website, Markdown, YAML, Python and Notebook links with retry
         if: github.event_name == 'workflow_dispatch'
         uses: ultralytics/actions/retry@main
         with:
@@ -84,7 +83,6 @@ jobs:
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
             './**/*.md' \
-            './**/*.html' \
             './**/*.yml' \
             './**/*.yaml' \
             './**/*.py' \

--- a/.github/workflows/links_local.yml
+++ b/.github/workflows/links_local.yml
@@ -41,7 +41,7 @@ jobs:
           curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
             sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
-      - name: Test Markdown links with retry
+      - name: Test Markdown and HTML links with retry
         uses: ultralytics/actions/retry@main
         with:
           timeout_minutes: 60
@@ -51,6 +51,7 @@ jobs:
             rm -rf .lycheecache
             lychee \
             --scheme 'https' \
+            --extensions md,html \
             --timeout 60 \
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
@@ -60,9 +61,9 @@ jobs:
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
-            './**/*.md'
+            .
 
-      - name: Test Website, Markdown, YAML, Python and Notebook links with retry
+      - name: Test Website, Markdown, HTML, YAML, Python and Notebook links with retry
         if: github.event_name == 'workflow_dispatch'
         uses: ultralytics/actions/retry@main
         with:
@@ -73,6 +74,7 @@ jobs:
             rm -rf .lycheecache
             lychee \
             --scheme 'https' \
+            --extensions md,html,yml,yaml,py,ipynb \
             --timeout 60 \
             --insecure \
             --accept 100..=103,200..=299,302,401,402,403,415,429,500..=599,999 \
@@ -82,8 +84,4 @@ jobs:
             --exclude-path './**/ci.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
-            './**/*.md' \
-            './**/*.yml' \
-            './**/*.yaml' \
-            './**/*.py' \
-            './**/*.ipynb'
+            .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,11 @@ After opening a PR:
 ## Commands
 
 ```bash
-uv pip install -r requirements.txt                     # beautifulsoup4, requests, pandas (for utils/)
-uv run python utils/check_image_sizes.py DOWNLOAD_DIR WEBSITE  # flag images >750 KB, as links.yml runs it
-lychee --scheme 'https' './**/*.md' './**/*.html'      # PR link check (simplified); CI adds more flags, see .github/workflows/links_local.yml
-npx prettier --write "**/*.md" "**/*.yml"              # Markdown/YAML formatting
-codespell docs utils README.md                          # spelling
+uv pip install -r requirements.txt                            # beautifulsoup4, requests, pandas (for utils/)
+uv run python utils/check_image_sizes.py DOWNLOAD_DIR WEBSITE # flag images >750 KB, as links.yml runs it
+lychee --scheme 'https' './**/*.md' './**/*.html'             # PR link check (simplified); CI adds more flags, see .github/workflows/links_local.yml
+npx prettier --write "**/*.md" "**/*.yml"                     # Markdown/YAML formatting
+codespell docs utils README.md                                # spelling
 ```
 
 - There is no test suite, build, or coverage — PR CI is `links_local.yml` (lychee over all repo `*.md`/`*.html` against the live web, so a dead URL fails CI) plus Ultralytics Actions formatting in `format.yml` (source of truth for Prettier/Ruff/docformatter/codespell settings; it runs them server-side on PRs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ After opening a PR:
 
 ```bash
 uv pip install -r requirements.txt                     # beautifulsoup4, requests, pandas (for utils/)
-uv run python utils/check_image_sizes.py <download_dir> <website>  # flag images >750 KB, as links.yml runs it
+uv run python utils/check_image_sizes.py DOWNLOAD_DIR WEBSITE  # flag images >750 KB, as links.yml runs it
 lychee --scheme 'https' './**/*.md' './**/*.html'      # PR link check (simplified); CI adds more flags, see .github/workflows/links_local.yml
 npx prettier --write "**/*.md" "**/*.yml"              # Markdown/YAML formatting
 codespell docs utils README.md                          # spelling
@@ -43,7 +43,7 @@ codespell docs utils README.md                          # spelling
 
 ## Architecture
 
-This repo is one public content source for https://docs.ultralytics.com/. Additional source lives in `ultralytics/ultralytics` under `docs/en/`; CI combines the sources before running `zensical build --strict`. Relative links may therefore resolve only in the complete content tree. This repository intentionally has no standalone Zensical configuration or site build; the centralized publisher renders and deploys production.
+This repo is one public content source for https://docs.ultralytics.com/. Additional source lives in `ultralytics/ultralytics` under `docs/en/`; the centralized validation path combines the sources before running `zensical build --strict`. Relative links may therefore resolve only in the complete content tree. This repository intentionally has no standalone Zensical configuration or site build; the centralized publisher renders and deploys production.
 
 The remaining workflows handle docs-specific publishing, website QA, and housekeeping: `publish.yml` triggers the centralized publisher on every `main` push and daily; `links.yml` downloads rendered www/docs/academy/handbook sites and checks links, spelling, and image sizes; `links_local.yml` checks repository links on push, PR, and daily; `download_websites.yml` is manual-only; and `stale.yml` manages inactive issues and PRs. Releases are manual: `tag.yml` is `workflow_dispatch`-only and gated to `github.repository == 'ultralytics/docs' && github.actor == 'glenn-jocher'`; there is no version file or package publish.
 


### PR DESCRIPTION
## Summary

- replace invalid shell placeholder syntax in the documented image-size command
- describe the existing centralized strict Zensical validation path accurately

This removes the shfmt parse error visible in the formatting-action log.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated documentation validation instructions and local link-check workflows to use valid shell syntax and accurately describe centralized Zensical validation, preventing the documented command from triggering a shfmt parse error.

### 📊 Key Changes

- Replaced `<download_dir>` and `<website>` with the literal placeholders `DOWNLOAD_DIR` and `WEBSITE` in the documented image-size check command.
- Updated `links_local.yml` to run `lychee` from the repository root with explicit extension filters for Markdown/HTML checks and broader manual checks covering YAML, Python, and notebooks.
- Clarified in `AGENTS.md` that centralized validation combines documentation sources before running `zensical build --strict`, while this repository has no standalone Zensical configuration or build.

### 🎯 Purpose & Impact

- The documented shell command can be parsed by formatting checks without treating angle-bracket placeholders as shell syntax.
- Local link validation now uses extension filters with a repository-root input instead of separate file globs.
- Documentation about the Zensical validation workflow now matches the existing centralized process; no direct production site behavior changes are introduced.