### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,7 @@ on:
   issues:
     types: [opened]
   pull_request:
+    branches: [main]
     types: [opened, closed, synchronize, review_requested]
 
 permissions:


### PR DESCRIPTION
- Restrict the `format.yml` `pull_request` trigger to `branches: [main]`, matching the org standard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the formatting workflow to run on pull request activity targeting `main`, aligning it with the organization’s standard configuration.

### 📊 Key Changes

- Added `branches: [main]` to the `pull_request` trigger in `.github/workflows/format.yml`.
- Preserved the existing triggers for opened, closed, synchronized, and review-requested pull request events.

### 🎯 Purpose & Impact

- Formatting workflow runs only for the specified pull request events when the target branch is `main`.
- No user-facing change.